### PR TITLE
Remove audio_bus_destroy stub

### DIFF
--- a/scripts/Unsupported.js
+++ b/scripts/Unsupported.js
@@ -490,7 +490,6 @@ function audio_sync_group_is_paused()                  	{ ErrorFunction("audio_s
 function audio_sync_group_debug()                   	{ ErrorFunction("audio_sync_group_debug()"); }
 
 function audio_bus_create()                   			{ ErrorFunction("audio_bus_create()"); }
-function audio_bus_destroy()                   			{ ErrorFunction("audio_bus_destroy()"); }
 function audio_effect_create() 							{ ErrorFunction("audio_effect_create()"); }
 function audio_emitter_bus()							{ ErrorFunction("audio_emitter_bus()"); }
 function audio_emitter_get_bus()						{ ErrorFunction("audio_emitter_get_bus()"); }


### PR DESCRIPTION
Removes the HTML5 stub for the temporary function `audio_bus_destroy`.