### PR TITLE
[HTML5] Add audio effects feature flag

### DIFF
--- a/scripts/yySound.js
+++ b/scripts/yySound.js
@@ -792,6 +792,8 @@ class AudioMixer
 	constructor()
 	{
 		this.mainBus = new AudioBus();
-		g_pBuiltIn.audio_bus_main = this.mainBus;
+
+		if (IsFeatureEnabled("audio-fx"))
+			g_pBuiltIn.audio_bus_main = this.mainBus;
 	}
 }


### PR DESCRIPTION
Adds the feature flag "audio-fx" to the HTML5 runner.

As all the functions are stubbed anyway, this will only disable the built-in `audio_bus_main`.