### PR TITLE
GM-5999: Add 'type' member to effect structs

### DIFF
--- a/scripts/sound/AudioEffect.js
+++ b/scripts/sound/AudioEffect.js
@@ -1,6 +1,4 @@
-function AudioEffect() {
-    AudioWorkletNode.call(this);
-}
+function AudioEffect() {}
 
 AudioEffect.PARAM_TIME_CONSTANT = 0.005; // 5ms
 
@@ -40,6 +38,15 @@ function AudioEffectStruct(_type) {
     
     // Define user-facing properties
     Object.defineProperties(this, {
+        gmltype: {
+            enumerable: true,
+            get: () => {
+                return this.type;  
+            },
+            set: (_type) => {
+                throw new Error("Unable to set AudioEffect.type - property is read-only");
+            }
+        },
         gmlbypass: {
             enumerable: true,
             get: () => {

--- a/scripts/sound/worklets/BitcrusherProcessor.js
+++ b/scripts/sound/worklets/BitcrusherProcessor.js
@@ -38,7 +38,7 @@ class BitcrusherProcessor extends KillableWorkletProcessor
         const maxChannels = _options.outputChannelCount[0];
 
         this.sample = new Float32Array(maxChannels);
-        this.hold = new Float32Array(maxChannels);
+        this.hold = new Uint32Array(maxChannels);
     }
 
     process(inputs, outputs, parameters) 

--- a/scripts/sound/worklets/Reverb1Processor.js
+++ b/scripts/sound/worklets/Reverb1Processor.js
@@ -122,10 +122,10 @@ class Reverb1Processor extends KillableWorkletProcessor
     static get parameterDescriptors() 
     {
         return [
-            { name: "bypass", automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: 1 },
-            { name: "size",   automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: 1 },
-            { name: "damp",   automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: 1 },
-            { name: "mix",    automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: 1 }
+            { name: "bypass", automationRate: "a-rate", defaultValue: 0,    minValue: 0, maxValue: 1 },
+            { name: "size",   automationRate: "a-rate", defaultValue: 0.5,  minValue: 0, maxValue: 1 },
+            { name: "damp",   automationRate: "a-rate", defaultValue: 0.5,  minValue: 0, maxValue: 1 },
+            { name: "mix",    automationRate: "a-rate", defaultValue: 0,    minValue: 0, maxValue: 1 }
         ];
     }
 


### PR DESCRIPTION
Adds the `type` member to all `AudioEffect` structs.

This is a member which simply holds the value of `AudioEffectType` that was used to create the struct.

The member is read-only, so any attempt to overwrite it will generate an error.

Other changes:
* Aligned default values of params in the `Reverb1Processor` with its effect struct.
* Changed the type of an array in `BitcrusherProcessor`.
* Removed an unnessecary call to `AudioWorkletNode()` in `AudioEffect()`.