### PR TITLE
GM-5931: Clip track offsets greater than length of audio

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -2006,8 +2006,12 @@ function Audio_SetTrackPos( _audioSound, _time )
             //AudioBufferSourceNode- cannot call start/noteOn more than once- have to stop and replay at time offset
             //Audio_StopUnstreamed( _audioSound );
             //don't need to disconnect gain nodes since we are reusing audioSound
+            const duration = _audioSound.pbuffersource.buffer.duration;
+
             if (_time >= 0)
             {
+                _time = Math.min(_time, duration);
+
                 if (_audioSound.paused)
                 {
                     //simply need to resume at different offset
@@ -2033,11 +2037,13 @@ function Audio_SetTrackPos( _audioSound, _time )
         	if (isNaN(duration))
         	{
         		_audioSound.audio_tag.addEventListener('loadedmetadata', function() {
-                      _audioSound.audio_tag.currentTime = _time;
-                    });
+                    _time = Math.min(_time, this.duration);
+                    this.currentTime = _time;
+                });
         	}
             else if (_time >= 0)
             {
+                _time = Math.min(_time, duration);
                 _audioSound.audio_tag.currentTime = _time;
             }
         }


### PR DESCRIPTION
When calling `audio_sound_set_track_position`, we would ignore any offset at or beyond the end of the audio. This is inconsistent with how the optional offset argument for `audio_play_sound_x` works, which would clip the offset to the end of the audio, as is also done by [`AudioBufferSourceNode`](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start) and [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentTime).

This aligns the behaviour between the two methods of setting the offset to the latter. Negative values are still ignored.

