### PR TITLE
GM-6176: Clip voice-level offset only if specified

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -575,8 +575,11 @@ class AudioPlaybackProps
         this.loop = yyGetReal(_loop);
 
         this.gain = Math.max(0, _gain);
-        this.offset = Math.max(0, _offset);
         this.pitch = Math.max(0, _pitch);
+        this.offset = _offset;
+
+        if (this.offset !== AudioPropsCalc.not_specified)
+            this.offset = Math.max(0, _offset);
     }
 
     Invalid()


### PR DESCRIPTION
The voice level offset was being clipped without first checking whether it was equal to `AudioPropsCalc::not_specified`, which is equal to -1. We should preserve `AudioPropsCalc::not_specified` as it is checked for in the offset calculation.