### PR TITLE
GM-6045: Allow time source callbacks to be script-index functions

### DIFF
--- a/scripts/yyTime.js
+++ b/scripts/yyTime.js
@@ -781,7 +781,6 @@ class CConfigurableTimeSource extends CStatefulTimeSource
     /* Validates the requested callback */
     ValidateCallback(_callback)
     {
-        // Maybe we should check whether its a function?
         if (typeof _callback != 'function'
         && (typeof _callback != 'number' || script_get(_callback) === null))
         {


### PR DESCRIPTION
Time source callbacks can be both a function (for a method) or a number (for a script-index function).

In `CConfigurableTimeSource.ValidateCallback`, script-index functions were being incorrectly treated as invalid. We'll now accept that the callback could indeed be a number, and call the corresponding function if it is.