### PR TITLE
GM-5985: Check game dir when loading audio worklets

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -134,7 +134,7 @@ function audio_init()
     g_AudioMainVolumeNode = new GainNode(g_WebAudioContext);
     g_AudioMainVolumeNode.connect(g_WebAudioContext.destination);
 
-    g_WebAudioContext.audioWorklet.addModule("html5game/sound/worklets/audio-worklet.js")
+    g_WebAudioContext.audioWorklet.addModule(g_pGMFile.Options.GameDir + "/sound/worklets/audio-worklet.js")
     .then(() => {
         g_AudioBusMain = new AudioBus();
         g_AudioBusMain.connectOutput(g_AudioMainVolumeNode);


### PR DESCRIPTION
This fixes another bug exposed while fixing [GM-5985](https://bugs.opera.com/browse/GM-5985). When trying to load the audio worklets, we weren't grabbing the actual game directory from the game options.