### PR TITLE
Add tileset_get_info function

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -3572,6 +3572,62 @@ function tileset_get_uvs(_ind) {
     return null;
 }
 
+function tileset_get_info(_ind) {
+
+    var pDest = g_pBackgroundManager.GetImage(yyGetInt32(_ind));
+    var ret = undefined;
+    if( pDest) {
+        ret = new GMLObject();
+
+        var pTPE = pDest.TPEntry;        
+        var texture = pTPE.texture;
+        variable_struct_set(ret, "width", texture.width); 
+        variable_struct_set(ret, "height", texture.height); 
+        variable_struct_set(ret, "texture", pTPE.tp); 
+        variable_struct_set(ret, "tile_width", pDest.tilewidth); 
+        variable_struct_set(ret, "tile_height", pDest.tileheight); 
+        variable_struct_set(ret, "tile_horizontal_separator", pDest.tilehsep); 
+        variable_struct_set(ret, "tile_vertical_separator", pDest.tilevsep); 
+        variable_struct_set(ret, "tile_columns", pDest.tilecolumns); 
+        variable_struct_set(ret, "tile_count", pDest.tilecount); 
+        variable_struct_set(ret, "frame_count", pDest.frames); 
+        variable_struct_set(ret, "frame_length_ms", pDest.framelength); 
+
+        var frames = new GMLObject();
+        for( var t = 0; t < pDest.tilecount; ++t) {
+
+            var allFramesSame = true;
+            for( var f=0; allFramesSame &&  f<pDest.frames; ++f) {
+
+                var tt = pDest.framedata[ (t*pDest.frames) + f ];
+                if (tt == 0) break;
+                allFramesSame = (tt == t);
+
+            } // end for
+
+            // goto next tile if all frames are the same in the framedata.
+            if (allFramesSame) continue;
+
+
+            var fr = [];            
+            for( var f=0; f<pDest.frames; ++f) {
+
+                var tt = pDest.framedata[ (t*pDest.frames) + f ];
+                if (tt == 0) break;
+
+                fr[f] = tt;
+            } // end for
+
+            variable_struct_set(frames, t.toString(), fr); 
+        } // end for
+
+        variable_struct_set(ret, "frames", frames); 
+    } // end if
+
+    return ret;
+}
+
+
 function tilemap_get_tileset( arg1) 
 {
     var room = g_pLayerManager.GetTargetRoomObj();


### PR DESCRIPTION
* returns a struct (or undefined if argument is not a tileset).
* struct contains
* width - width of the whole tileset texture
* height - height of the whole tileset texture
* texture - texture number 
* tile_width - width of a single tile (in pixels)
* tile_height - height of a single tile (in pixels)
* tile_horizontal_separator - number of pixels horixontally between each tile
* tile_vertical_separator - number of pixels vertically between each tile
* tile_columns - number of columns on each row of the tileset.
* tile_count - number of tiles
* frame_count - number of frames of animation per anim.
* frame_length_ms - number of milliseconds for frame animation
* frames - struct of all the anim frames, key is the tile number each entry is an array of the frames to use (each array should be frame_count long).
