### PR TITLE
Fix instanceof(global) returning `undefined` instead of `"global"`

### DIFF
--- a/scripts/GameGlobals.js
+++ b/scripts/GameGlobals.js
@@ -18,4 +18,5 @@
 
 function    yyGameGlobals()
 {
+	this.__type = "global";
 }


### PR DESCRIPTION
(issue #66)