### PR TITLE
GM-6371: Add fn audio_bus_get_emitters

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3991,6 +3991,11 @@ function audio_emitter_bus(_emitterIdx, _bus)
     if (emitter === undefined)
         return;
 
+    const busType = g_UseDummyAudioBus ? DummyAudioBus : AudioBus;
+
+    if (!(_bus instanceof busType))
+        yyError("audio_emitter_bus() - argument 'bus' should be a Struct.AudioBus");
+
     emitter.gainnode.disconnect();
     _bus.connectInput(emitter.gainnode);
     emitter.bus = _bus;
@@ -4004,4 +4009,21 @@ function audio_emitter_get_bus(_emitterIdx)
         return undefined;
 
     return emitter.bus;
+}
+
+function audio_bus_get_emitters(_bus)
+{
+    const busType = g_UseDummyAudioBus ? DummyAudioBus : AudioBus;
+
+    if (!(_bus instanceof busType))
+        yyError("audio_bus_get_emitters() - argument 'bus' should be a Struct.AudioBus");
+
+    const emitterIds = [];
+
+    for (const id in audio_emitters) {
+        if (audio_emitters[id].bus === _bus)
+            emitterIds.push(Number(id));
+    }
+
+    return emitterIds;
 }


### PR DESCRIPTION
Adds a new function `audio_bus_get_emitters(bus: Struct.AudioBus) -> Array[Id.AudioEmitter]` which will return an array of all of the emitters linked to a given audio bus.

Also checks that the bus given to `audio_emitter_bus` is indeed an audio bus.