### PR TITLE
GM-4983: Add fn audio_play_sound_ext

### DIFF
--- a/scripts/runner.js
+++ b/scripts/runner.js
@@ -149,6 +149,8 @@ document.write('<script type="text/javascript" src="scripts/fingerprintjs/finger
 document.write('<script type="text/javascript" src="scripts/sound/WorkletNodeManager.js"></script>');
 document.write('<script type="text/javascript" src="scripts/sound/AudioBus.js"></script>');
 document.write('<script type="text/javascript" src="scripts/sound/AudioEffect.js"></script>');
+document.write('<script type="text/javascript" src="scripts/sound/AudioPlaybackProps.js"></script>');
+document.write('<script type="text/javascript" src="scripts/sound/AudioPropsCalc.js"></script>');
 document.write('<script type="text/javascript" src="scripts/sound/effects/Bitcrusher.js"></script>');
 document.write('<script type="text/javascript" src="scripts/sound/effects/Delay.js"></script>');
 document.write('<script type="text/javascript" src="scripts/sound/effects/Gain.js"></script>');

--- a/scripts/sound/AudioPlaybackProps.js
+++ b/scripts/sound/AudioPlaybackProps.js
@@ -1,0 +1,77 @@
+var AudioPlaybackType = {
+    NON_POSITIONAL: 0,
+    POSITIONAL_SPECIFIED: 1,
+    POSITIONAL_EMITTER: 2
+};
+
+function AudioPlaybackProps(_props) {
+    if (this.getProp(_props, "sound", this, "asset_index", true, yyGetInt32, AudioPropsCalc.invalid_index))
+        this.asset = Audio_GetSound(this.asset_index);
+
+    if (this.getProp(_props, "emitter", this, "emitter_index", true, yyGetInt32, AudioPropsCalc.invalid_index)) {
+        this.type = AudioPlaybackType.POSITIONAL_EMITTER;
+        this.emitter = audio_emitters[this.emitter_index];
+    }
+    
+    this.getProp(_props, "priority", this, "priority", true, yyGetReal, AudioPropsCalc.default_priority);
+    this.getProp(_props, "loop", this, "loop", true, yyGetReal, AudioPropsCalc.default_loop);
+    this.getProp(_props, "gain", this, "gain", true, yyGetReal, AudioPropsCalc.default_gain);
+    this.getProp(_props, "offset", this, "offset", true, yyGetReal, AudioPropsCalc.not_specified);
+    this.getProp(_props, "pitch", this, "pitch", true, yyGetReal, AudioPropsCalc.default_pitch);
+
+    if (typeof _props.gmlposition === "object" && this.type === undefined) {
+            this.type = AudioPlaybackType.POSITIONAL_SPECIFIED;
+
+            const position = _props.position ?? _props.gmlposition;
+            this.position = {};
+
+            this.getProp(position, "x", this.position, "x", false, yyGetReal, 0);
+            this.getProp(position, "y", this.position, "y", false, yyGetReal, 0);
+            this.getProp(position, "z", this.position, "z", false, yyGetReal, 0);
+            this.getProp(position, "falloff_ref", this.position, "falloff_ref", true, yyGetReal, 0);
+            this.getProp(position, "falloff_max", this.position, "falloff_max", true, yyGetReal, 1);
+            this.getProp(position, "falloff_factor", this.position, "falloff_factor", true, yyGetReal, 1);
+    }
+
+    this.type ??= AudioPlaybackType.NON_POSITIONAL;
+}
+
+AudioPlaybackProps.prototype.getProp = function(_srcObj, _srcKey, _destObj, _destKey, 
+    _gmlPrefix, _converterFn, _default) {
+    if (_srcObj[_srcKey] !== undefined) {
+        _destObj[_destKey] = _converterFn(_srcObj[_srcKey]);
+        return true;
+    }
+    
+    if (_gmlPrefix && _srcObj["gml" + _srcKey] !== undefined) {
+        _destObj[_destKey] = _converterFn(_srcObj["gml" + _srcKey]);
+        return true;
+    }
+
+    _destObj[_destKey] = _default;
+    return false;
+};
+
+AudioPlaybackProps.prototype.invalid = function() {
+    if (this.asset == null) {
+        debug("Audio playback failed - invalid asset index: " + this.asset_index);
+        return true;
+    }
+
+    if (!audio_group_is_loaded(this.asset.groupId)) {
+        debug(audio_get_name(this.asset_index) + ": Audio Group " + this.asset.groupId + " is not loaded");
+        return true;
+    }
+
+    if (!Audio_WebAudioPlaybackAllowed()) {
+        debug("Audio playback failed. WebAudio Context suspended (user must interact with the page before audio can be played).");
+        return true;
+    }
+
+    if (this.type === AudioPlaybackType.POSITIONAL_EMITTER && this.emitter === undefined) {
+        debug("Attempting to play sound on inactive emitter: " + this.emitter_index);
+        return true;
+    }
+
+    return false;
+};

--- a/scripts/sound/AudioPropsCalc.js
+++ b/scripts/sound/AudioPropsCalc.js
@@ -1,0 +1,83 @@
+function AudioPropsCalc() {}
+
+AudioPropsCalc.invalid_index = -1;
+AudioPropsCalc.not_specified = -1;
+AudioPropsCalc.default_priority = 0;
+AudioPropsCalc.default_loop = false;
+AudioPropsCalc.default_gain = 1;
+AudioPropsCalc.default_offset = 0;
+AudioPropsCalc.default_pitch = 1;
+
+AudioPropsCalc.CalcGain = function(_voice) {
+    const asset = AudioPropsCalc.GetAssetProps(_voice.soundid);
+    const group = AudioPropsCalc.GetGroupProps(_voice.soundid);
+    // Emitter gains are stored in their own audio node and 
+    // will be multiplied with this value by the audio context
+    return _voice.gain.get() * asset.gain.get() * group.gain.get();
+};
+
+AudioPropsCalc.CalcOffset = function(_voice) {
+    if (_voice.startoffset == AudioPropsCalc.not_specified) {
+        const asset = AudioPropsCalc.GetAssetProps(_voice.soundid);
+        return asset.offset;
+    }
+
+    return _voice.startoffset;
+}
+
+AudioPropsCalc.CalcPitch = function(_voice) {
+    const asset = AudioPropsCalc.GetAssetProps(_voice.soundid);
+    const emitter = AudioPropsCalc.GetEmitterProps(_voice.pemitter);
+
+    return _voice.pitch * asset.pitch * emitter.pitch;
+}
+
+AudioPropsCalc.GetAssetProps = function(_asset_index) {
+    const asset = Audio_GetSound(_asset_index);
+
+    if (asset != null) {
+        return (() => ({
+            gain: asset.gain,
+            offset: asset.trackPos,
+            pitch: asset.pitch
+        }))();
+    }
+
+    return (() => ({
+        gain: AudioPropsCalc.default_gain,
+        offset: AudioPropsCalc.default_offset,
+        pitch: AudioPropsCalc.default_pitch
+    }))();
+}
+
+AudioPropsCalc.GetEmitterProps = function(_emitter) {
+    if (_emitter != null) {
+        return (() => ({
+            gain: _emitter.gainnode.gain.value,
+            pitch: _emitter.pitch
+        }))();
+    }
+
+    return (() => ({
+        gain: AudioPropsCalc.default_gain,
+        pitch: AudioPropsCalc.default_pitch
+    }))();
+}
+
+AudioPropsCalc.GetGroupProps = function(_assetIndex) {
+    const asset = Audio_GetSound(_assetIndex);
+
+    if (asset != null) {
+        const group = g_AudioGroups[asset.groupId];
+
+        if (group !== undefined) {
+            return (() => ({
+                gain: group.gain,
+            }))();
+        }
+    }
+
+    return (() => ({
+        gain: AudioPropsCalc.default_gain,
+    }))();
+}


### PR DESCRIPTION
- Added a new function `audio_play_sound_ext`, which takes a struct specifying any non-default playback parameters.
- Merged common behaviour from `audio_play_sound`, `audio_play_sound_at`, `audio_play_sound_on` and `audio_play_sound_ext` into `audio_play_sound_common`. The GML functions now just configure the `AudioPlaybackProps` object which feeds `audio_play_sound_common`.
- Moved `AudioPlaybackProps` and `AudioPropsCalc` into their own files in order to clean up Function_Sound.js a bit.