### PR TITLE
Avoid GML internal properties to be copied into a new instance.

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -4259,6 +4259,7 @@ function ShallowCopyVars( _dest, _other)
 {
     if (_other != undefined) {
         var props = Object.getOwnPropertyNames(_other);
+        props = props.filter(val => !val.startsWith("__"));
         for (var i = 0; i < props.length; i++)
         {
             var prop = props[i];


### PR DESCRIPTION
The GML internal properties (ie.: __type, __yyIsGmlObject) were being copied over into the new instance when a shallow copy was being attempted. This would "turn" the new instance of type instance into a struct, breaking the game.