### PR TITLE
GM-6340: Create audio effects with sensible default values

### DIFF
--- a/scripts/sound/effects/Bitcrusher.js
+++ b/scripts/sound/effects/Bitcrusher.js
@@ -67,8 +67,8 @@ function BitcrusherEffectStruct(_params) {
 
 BitcrusherEffectStruct.paramDescriptors = () => ({
     bypass:     AudioEffectStruct.paramDescriptors().bypass,
-    gain:       { name: "gain",       integer: false, defaultValue: 1,  minValue: 0, maxValue: Number.MAX_VALUE },
-    factor:     { name: "factor",     integer: true,  defaultValue: 1,  minValue: 1, maxValue: 100 },
-    resolution: { name: "resolution", integer: true,  defaultValue: 16, minValue: 2, maxValue: 16  },
-    mix:        { name: "mix",        integer: false, defaultValue: 0,  minValue: 0, maxValue: 1   }
+    gain:       { name: "gain",       integer: false, defaultValue: 1.0, minValue: 0.0, maxValue: Number.MAX_VALUE },
+    factor:     { name: "factor",     integer: true,  defaultValue: 20,  minValue: 1,   maxValue: 100 },
+    resolution: { name: "resolution", integer: true,  defaultValue: 8,   minValue: 2,   maxValue: 16  },
+    mix:        { name: "mix",        integer: false, defaultValue: 0.8, minValue: 0.0, maxValue: 1.0 }
 });

--- a/scripts/sound/effects/Delay.js
+++ b/scripts/sound/effects/Delay.js
@@ -53,7 +53,7 @@ function DelayEffectStruct(_params) {
 
 DelayEffectStruct.paramDescriptors = () => ({
     bypass:   AudioEffectStruct.paramDescriptors().bypass,
-    time:     { name: "time",     integer: false, defaultValue: 0, minValue: 0, maxValue: 5 },
-    feedback: { name: "feedback", integer: false, defaultValue: 0, minValue: 0, maxValue: 1 },
-    mix:      { name: "mix",      integer: false, defaultValue: 0, minValue: 0, maxValue: 1 }
+    time:     { name: "time",     integer: false, defaultValue: 0.2,  minValue: 0.0, maxValue: 5.0 },
+    feedback: { name: "feedback", integer: false, defaultValue: 0.5,  minValue: 0.0, maxValue: 1.0 },
+    mix:      { name: "mix",      integer: false, defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
 });

--- a/scripts/sound/effects/Gain.js
+++ b/scripts/sound/effects/Gain.js
@@ -25,5 +25,5 @@ function GainEffectStruct(_params) {
 
 GainEffectStruct.paramDescriptors = () => ({
     bypass: AudioEffectStruct.paramDescriptors().bypass,
-    gain:   { name: "gain", integer: false, defaultValue: 1, minValue: 0, maxValue: Number.MAX_VALUE }
+    gain:   { name: "gain", integer: false, defaultValue: 0.5, minValue: 0.0, maxValue: Number.MAX_VALUE }
 });

--- a/scripts/sound/effects/HPF2.js
+++ b/scripts/sound/effects/HPF2.js
@@ -39,11 +39,12 @@ function HPF2EffectStruct(_params) {
 
 HPF2EffectStruct.paramDescriptors = () => ({
     bypass: AudioEffectStruct.paramDescriptors().bypass,
-    freq:   { name: "cutoff", integer: false, defaultValue: 10, minValue: 10, maxValue: 20000 },
-    q:      { name: "q",      integer: false, defaultValue: 1,  minValue: 1,  maxValue: 100 },
+    freq:   { name: "cutoff", integer: false, defaultValue: 1500.0, minValue: 10.0, maxValue: 20000.0 },
+    q:      { name: "q",      integer: false, defaultValue: 1.5,    minValue: 1.0,  maxValue: 100.0 },
 
     get cutoff() {
-        this.freq.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2, this.freq.maxValue) : this.freq.maxValue;
+        this.freq.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2.0, this.freq.maxValue) : this.freq.maxValue;
+        this.freq.defaultValue = Math.min(this.freq.defaultValue, this.freq.maxValue);
         return this.freq;
     } 
 });

--- a/scripts/sound/effects/LPF2.js
+++ b/scripts/sound/effects/LPF2.js
@@ -39,12 +39,12 @@ function LPF2EffectStruct(_params) {
 
 LPF2EffectStruct.paramDescriptors = () => ({
     bypass: AudioEffectStruct.paramDescriptors().bypass,
-    freq:   { name: "cutoff", integer: false, defaultValue: 20000, minValue: 10, maxValue: 20000 },
-    q:      { name: "q",      integer: false, defaultValue: 1,     minValue: 1,  maxValue: 100 },
+    freq:   { name: "cutoff", integer: false, defaultValue: 500.0, minValue: 10.0, maxValue: 20000.0 },
+    q:      { name: "q",      integer: false, defaultValue: 1.5,   minValue: 1.0,  maxValue: 100.0 },
 
     get cutoff() {
-        this.freq.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2, this.freq.maxValue) : this.freq.maxValue;
-        this.freq.defaultValue = this.freq.maxValue;
+        this.freq.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2.0, this.freq.maxValue) : this.freq.maxValue;
+        this.freq.defaultValue = Math.min(this.freq.defaultValue, this.freq.maxValue);
         return this.freq;
     } 
 });

--- a/scripts/sound/effects/Reverb1.js
+++ b/scripts/sound/effects/Reverb1.js
@@ -53,7 +53,7 @@ function Reverb1EffectStruct(_params) {
 
 Reverb1EffectStruct.paramDescriptors = () => ({
     bypass: AudioEffectStruct.paramDescriptors().bypass,
-    size:   { name: "size", integer: false, defaultValue: 0.5, minValue: 0, maxValue: 1 },
-    damp:   { name: "damp", integer: false, defaultValue: 0.5, minValue: 0, maxValue: 1 },
-    mix:    { name: "mix",  integer: false, defaultValue: 0,   minValue: 0, maxValue: 1 }
+    size:   { name: "size", integer: false, defaultValue: 0.7,  minValue: 0.0, maxValue: 1.0 },
+    damp:   { name: "damp", integer: false, defaultValue: 0.1,  minValue: 0.0, maxValue: 1.0 },
+    mix:    { name: "mix",  integer: false, defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
 });

--- a/scripts/sound/worklets/BitcrusherProcessor.js
+++ b/scripts/sound/worklets/BitcrusherProcessor.js
@@ -3,11 +3,11 @@ class BitcrusherProcessor extends AudioWorkletProcessor
     static get parameterDescriptors() 
     {
         return [
-            { name: "bypass",     automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: 1 },
-            { name: "gain",       automationRate: "a-rate", defaultValue: 1,  minValue: 0 },
-            { name: "factor",     automationRate: "a-rate", defaultValue: 1,  minValue: 1, maxValue: 100 },
-            { name: "resolution", automationRate: "a-rate", defaultValue: 16, minValue: 2, maxValue: 16  },
-            { name: "mix",        automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: 1   }
+            { name: "bypass",     automationRate: "a-rate", defaultValue: 0,   minValue: 0,   maxValue: 1 },
+            { name: "gain",       automationRate: "a-rate", defaultValue: 1.0, minValue: 0.0 },
+            { name: "factor",     automationRate: "a-rate", defaultValue: 20,  minValue: 1,   maxValue: 100 },
+            { name: "resolution", automationRate: "a-rate", defaultValue: 8,   minValue: 2,   maxValue: 16  },
+            { name: "mix",        automationRate: "a-rate", defaultValue: 0.8, minValue: 0.0, maxValue: 1.0 }
         ];
     }
 

--- a/scripts/sound/worklets/DelayProcessor.js
+++ b/scripts/sound/worklets/DelayProcessor.js
@@ -1,14 +1,14 @@
 class DelayProcessor extends AudioWorkletProcessor
 {
-    static MAX_DELAY_TIME = 5; // seconds
+    static MAX_DELAY_TIME = 5.0; // seconds
 
     static get parameterDescriptors() 
     {
         return [
-            { name: "bypass",   automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: 1 },
-            { name: "time",     automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: DelayProcessor.MAX_DELAY_TIME },
-            { name: "feedback", automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: 1 },
-            { name: "mix",      automationRate: "a-rate", defaultValue: 0,  minValue: 0, maxValue: 1 }
+            { name: "bypass",   automationRate: "a-rate", defaultValue: 0,    minValue: 0,   maxValue: 1 },
+            { name: "time",     automationRate: "a-rate", defaultValue: 0.2,  minValue: 0.0, maxValue: DelayProcessor.MAX_DELAY_TIME },
+            { name: "feedback", automationRate: "a-rate", defaultValue: 0.5,  minValue: 0.0, maxValue: 1.0 },
+            { name: "mix",      automationRate: "a-rate", defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
         ];
     }
 

--- a/scripts/sound/worklets/GainProcessor.js
+++ b/scripts/sound/worklets/GainProcessor.js
@@ -3,8 +3,8 @@ class GainProcessor extends AudioWorkletProcessor
     static get parameterDescriptors() 
     {
         return [
-            { name: "bypass", automationRate: "a-rate", defaultValue: 0, minValue: 0, maxValue: 1 },
-            { name: "gain",   automationRate: "a-rate", defaultValue: 1, minValue: 0 }
+            { name: "bypass", automationRate: "a-rate", defaultValue: 0,   minValue: 0, maxValue: 1 },
+            { name: "gain",   automationRate: "a-rate", defaultValue: 0.5, minValue: 0.0 }
         ];
     }
 

--- a/scripts/sound/worklets/HPF2Processor.js
+++ b/scripts/sound/worklets/HPF2Processor.js
@@ -5,9 +5,9 @@ class HPF2Processor extends AudioWorkletProcessor
         const maxCutoff = Math.min(sampleRate / 2.0, 20000.0);
 
         return [
-            { name: "bypass", automationRate: "a-rate", defaultValue: 0,      minValue: 0,    maxValue: 1 },
-            { name: "cutoff", automationRate: "a-rate", defaultValue: 1500.0, minValue: 10.0, maxValue: maxCutoff },
-            { name: "q",      automationRate: "a-rate", defaultValue: 1.5,    minValue: 1.0,  maxValue: 100.0 }
+            { name: "bypass", automationRate: "a-rate", defaultValue: 0,                           minValue: 0,    maxValue: 1 },
+            { name: "cutoff", automationRate: "a-rate", defaultValue: Math.min(1500.0, maxCutoff), minValue: 10.0, maxValue: maxCutoff },
+            { name: "q",      automationRate: "a-rate", defaultValue: 1.5,                         minValue: 1.0,  maxValue: 100.0 }
         ];
     }
 

--- a/scripts/sound/worklets/HPF2Processor.js
+++ b/scripts/sound/worklets/HPF2Processor.js
@@ -2,12 +2,12 @@ class HPF2Processor extends AudioWorkletProcessor
 {
     static get parameterDescriptors() 
     {
-        const maxCutoff = Math.min(sampleRate / 2, 20000);
+        const maxCutoff = Math.min(sampleRate / 2.0, 20000.0);
 
         return [
-            { name: "bypass", automationRate: "a-rate", defaultValue: 0,  minValue: 0,  maxValue: 1 },
-            { name: "cutoff", automationRate: "a-rate", defaultValue: 10, minValue: 10, maxValue: maxCutoff },
-            { name: "q",      automationRate: "a-rate", defaultValue: 1,  minValue: 1,  maxValue: 100 }
+            { name: "bypass", automationRate: "a-rate", defaultValue: 0,      minValue: 0,    maxValue: 1 },
+            { name: "cutoff", automationRate: "a-rate", defaultValue: 1500.0, minValue: 10.0, maxValue: maxCutoff },
+            { name: "q",      automationRate: "a-rate", defaultValue: 1.5,    minValue: 1.0,  maxValue: 100.0 }
         ];
     }
 

--- a/scripts/sound/worklets/LPF2Processor.js
+++ b/scripts/sound/worklets/LPF2Processor.js
@@ -2,12 +2,12 @@ class LPF2Processor extends AudioWorkletProcessor
 {
     static get parameterDescriptors() 
     {
-        const maxCutoff = Math.min(sampleRate / 2, 20000);
+        const maxCutoff = Math.min(sampleRate / 2.0, 20000.0);
 
         return [
-            { name: "bypass", automationRate: "a-rate", defaultValue: 0,         minValue: 0,  maxValue: 1 },
-            { name: "cutoff", automationRate: "a-rate", defaultValue: maxCutoff, minValue: 10, maxValue: maxCutoff },
-            { name: "q",      automationRate: "a-rate", defaultValue: 1,         minValue: 1,  maxValue: 100 }
+            { name: "bypass", automationRate: "a-rate", defaultValue: 0,     minValue: 0,    maxValue: 1 },
+            { name: "cutoff", automationRate: "a-rate", defaultValue: 500.0, minValue: 10.0, maxValue: maxCutoff },
+            { name: "q",      automationRate: "a-rate", defaultValue: 1.5,   minValue: 1.0,  maxValue: 100.0 }
         ];
     }
 

--- a/scripts/sound/worklets/LPF2Processor.js
+++ b/scripts/sound/worklets/LPF2Processor.js
@@ -5,9 +5,9 @@ class LPF2Processor extends AudioWorkletProcessor
         const maxCutoff = Math.min(sampleRate / 2.0, 20000.0);
 
         return [
-            { name: "bypass", automationRate: "a-rate", defaultValue: 0,     minValue: 0,    maxValue: 1 },
-            { name: "cutoff", automationRate: "a-rate", defaultValue: 500.0, minValue: 10.0, maxValue: maxCutoff },
-            { name: "q",      automationRate: "a-rate", defaultValue: 1.5,   minValue: 1.0,  maxValue: 100.0 }
+            { name: "bypass", automationRate: "a-rate", defaultValue: 0,                          minValue: 0,    maxValue: 1 },
+            { name: "cutoff", automationRate: "a-rate", defaultValue: Math.min(500.0, maxCutoff), minValue: 10.0, maxValue: maxCutoff },
+            { name: "q",      automationRate: "a-rate", defaultValue: 1.5,                        minValue: 1.0,  maxValue: 100.0 }
         ];
     }
 

--- a/scripts/sound/worklets/Reverb1Processor.js
+++ b/scripts/sound/worklets/Reverb1Processor.js
@@ -122,10 +122,10 @@ class Reverb1Processor extends AudioWorkletProcessor
     static get parameterDescriptors() 
     {
         return [
-            { name: "bypass", automationRate: "a-rate", defaultValue: 0,    minValue: 0, maxValue: 1 },
-            { name: "size",   automationRate: "a-rate", defaultValue: 0.5,  minValue: 0, maxValue: 1 },
-            { name: "damp",   automationRate: "a-rate", defaultValue: 0.5,  minValue: 0, maxValue: 1 },
-            { name: "mix",    automationRate: "a-rate", defaultValue: 0,    minValue: 0, maxValue: 1 }
+            { name: "bypass", automationRate: "a-rate", defaultValue: 0,    minValue: 0,   maxValue: 1 },
+            { name: "size",   automationRate: "a-rate", defaultValue: 0.7,  minValue: 0.0, maxValue: 1.0 },
+            { name: "damp",   automationRate: "a-rate", defaultValue: 0.1,  minValue: 0.0, maxValue: 1.0 },
+            { name: "mix",    automationRate: "a-rate", defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
         ];
     }
 


### PR DESCRIPTION
Audio effects were created with parameter values set such that they would not have any perceivable effect. This was to force users to be explicit about how they wanted the effect to behave.

However, from a UX point of view, it can be quite confusing to put an effect on an audio bus and have it seemingly do nothing, so now they will be created with more normal (and perceivable) default values. 

In 2023.100 betas, users are able to initialise effect parameters on creation, so the option of being explicit is still available.