### PR TITLE
Made __internal__get_variable_names omit debug fields

### DIFF
--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -2453,6 +2453,7 @@ function __internal__get_variable_names( _struct, glob )
     for (var n in _struct) {
         if (_struct.hasOwnProperty(n)) {
             if (n.startsWith("gml")) {
+                if (g_DebugMode && n.startsWith('gml___struct___')) continue;
                 ret.push(n.substring(3));
                 ret.push(n);
             } // end if
@@ -2487,6 +2488,7 @@ function __internal__get_variable_names( _struct, glob )
         } // end else
 
         if (!transname.startsWith("gml")) {
+            if (g_DebugMode && n.startsWith('gml___struct___')) continue;
             ret.push(transname);
             ret.push(prop);
         } // end if


### PR DESCRIPTION
When running in debug mode, objects seem to have fields named `gml___struct___[number]`. 

I made `__internal__get_variable_names `omit them. Not sure if the better way would be to make objects not have those fields when running in debug mode.

Fixes https://github.com/YoYoGames/GameMaker-HTML5/issues/99