### PR TITLE
Fixed device_mouse_raw_x/y

### DIFF
--- a/scripts/functions/Function_YoYo.js
+++ b/scripts/functions/Function_YoYo.js
@@ -1068,13 +1068,9 @@ function device_mouse_raw_x(_dev) {
 
     _dev = yyGetInt32(_dev);
 
-	if (_dev == 0 && g_InputEvents[0])
+	if (g_InputEvents[_dev])
 	{
-		return g_InputEvents[0].x;
-	}
-	else if (g_TouchEvents[_dev])
-	{
-		return g_TouchEvents[_dev].x;
+		return g_InputEvents[_dev].x;
 	}
 	return 0;
 }
@@ -1118,13 +1114,9 @@ function device_mouse_raw_y(_dev) {
 
     _dev = yyGetInt32(_dev);
 
-	if (_dev == 0 && g_InputEvents[0])
+    if (g_InputEvents[_dev])
 	{
-		return g_InputEvents[0].y;
-	}
-	else if (g_TouchEvents[_dev])
-	{
-		return g_TouchEvents[_dev].y;
+		return g_InputEvents[_dev].y;
 	}
 	return 0;
 }


### PR DESCRIPTION
The device_mouse_raw_x/y functions are currently returning the same values as the device_mouse_x/y functions (room coordinates) for devices greater than 0, this pull request should fix those devices to behave as intended.