### PR TITLE
GM-6612: Use DummyAudioBus in insecure contexts

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -121,7 +121,6 @@ function audio_reinit()
     g_WebAudioContext.listener.ori = new Array(0,0,0,0,0,0);
 }
 
-
 function Audio_Init()
 {
     if (g_AudioModel !== Audio_WebAudio)
@@ -131,7 +130,8 @@ function Audio_Init()
     g_WebAudioContext.addEventListener("statechange", Audio_WebAudioContextOnStateChanged);
 
     g_HandleStreamedAudioAsUnstreamed = ( g_OSPlatform == BROWSER_IOS );
-    g_UseDummyAudioBus = (g_OSBrowser === BROWSER_SAFARI_MOBILE);
+    g_UseDummyAudioBus = (g_OSBrowser === BROWSER_SAFARI_MOBILE)
+                      || (g_WebAudioContext.audioWorklet === undefined);
 
     g_AudioMainVolumeNode = new GainNode(g_WebAudioContext);
     g_AudioMainVolumeNode.connect(g_WebAudioContext.destination);


### PR DESCRIPTION
[`BaseAudioContext.audioWorklet`](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/audioWorklet) is only available in secure contexts, and is undefined in insecure contexts.

Running a game in an insecure context (e.g. by accessing a locally hosted game from a device which isn't the host) would result in an unhandled exception as the audio engine depends on audio worklets (primarily for audio buses and effects).

Now, we will check whether or not `BaseAudioContext.audioWorklet` is available before trying to use it, and if not, then we'll fallback to using `DummyAudioBus` (as we do on iOS Safari). This will disable audio effects and reduce the feature set of audio buses.