### PR TITLE
Fixed variable_struct_exists

### DIFF
--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -2397,7 +2397,7 @@ function variable_instance_exists(_id, _var) {
                 }  
                 else {
                     if (pInst.__yyIsGMLObject) 
-                        ret = "gml"+_var in pInst;
+                        ret = _var in pInst || "gml"+_var in pInst;
                     else
                         ret = true;
                 } // end else


### PR DESCRIPTION
Currently when using a built-in variable inside a struct, and then using variable_struct_exists to check for existence of that variable, the function will return false.

```
a = { x: 123 }
show_message(variable_struct_exists(a, "x")) // returns false
```

With this pull request the code will now also look for the variable name without the "gml" prefix.

