### PR TITLE
fix audio resume crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -470,7 +470,7 @@ audioSound.prototype.resume = function() {
     }
     else {
         this.startoffset = this.playbackCheckpoint.bufferTime;
-        this.start();
+        this.start(this.pbuffersource.buffer);
     }
 
     this.paused = false;


### PR DESCRIPTION
Currently a crash will occur if you call `audio_pause_all()` and then `audio_resume_all()`.
This PR fixes that