### PR TITLE
GM-6370: Add fn audio_bus_clear_emitters

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3666,3 +3666,22 @@ function audio_bus_get_emitters(_bus)
 
     return emitterIds;
 }
+
+/* Relinks all of the emitters attached to the given bus back to the main bus. */
+function audio_bus_clear_emitters(_bus)
+{
+    const busType = g_UseDummyAudioBus ? DummyAudioBus : AudioBus;
+
+    if (g_AudioBusMain === null || (_bus instanceof busType) == false || _bus === g_AudioBusMain)
+        return;
+
+    for (const index in audio_emitters) {
+        const emitter = audio_emitters[index];
+
+        if (emitter.bus === _bus) {
+            emitter.gainnode.disconnect();
+            g_AudioBusMain.connectInput(emitter.gainnode);
+            emitter.bus = g_AudioBusMain;
+        }
+    }
+}


### PR DESCRIPTION
Adds the function `audio_bus_clear_emitters(bus: Struct.AudioBus) -> Undefined`, which will relink all of a given audio bus' emitters back to audio_bus_main.

Other side to this: https://github.com/YoYoGames/GameMaker/pull/1807