### PR TITLE
GM-6753: Call Audio_Init only after dependencies have been initialised

### DIFF
--- a/scripts/LoadGame.js
+++ b/scripts/LoadGame.js
@@ -44,7 +44,6 @@ function InitAboyne()
 	g_pBuiltIn.infinity = Number.POSITIVE_INFINITY;	
 	
 	Graphics_Init(canvas);
-	Audio_Init(); 
 
     g_pInstanceManager = new yyInstanceManager();
 	g_pObjectManager = new yyObjectManager();
@@ -65,6 +64,8 @@ function InitAboyne()
 	g_pEffectsManager = new yyEffectsManager();
     g_pCameraManager = new CameraManager();
     InitAboyneGlobals();
+
+    Audio_Init(); 
 
 	if (g_isZeus)
 	{

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -148,7 +148,7 @@ function Audio_Init()
         Audio_CreateMainBus();
     }
     else {
-        g_WebAudioContext.audioWorklet.addModule(g_pGMFile.Options.GameDir + "/sound/worklets/audio-worklet.js")
+        g_WebAudioContext.audioWorklet.addModule(g_RootDir + "/sound/worklets/audio-worklet.js")
         .then(() => {
             Audio_CreateMainBus();
         }).catch((_err) => {


### PR DESCRIPTION
When the audio context state changes, we generate an async event that provides a DS Map containing information about the state change. This is done in the state change event listener `Audio_EngineReportState`, which is set up in `Audio_Init`.

However, it seems that the audio context can sometimes start running before `g_ActiveMaps` has been initialised and in this scenario an exception will be thrown. 

These changes delay the call to `Audio_Init` so that it is guaranteed that all of the entities that `Audio_EngineReportState` depends on will have been initialised by the time the event listener is set up.

This also happens to guarantee that `g_RootDir` will have been initialised, so I've substituted that in for a direct reference to the game options too.