### PR TITLE
GM-6832: Check audio emitter existence before calling emitter functions from sequences

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -1734,6 +1734,9 @@ function audio_system() {
 /* Returns true if the an emitter both exists and is active. */
 function audio_emitter_exists(_emitterIndex)
 {
+    if (_emitterIndex === undefined)
+        return false;
+
     _emitterIndex = yyGetInt32(_emitterIndex);
 
     const emitter = audio_emitters[_emitterIndex];

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -4759,7 +4759,7 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
                             audio_sound_set_track_position(pAudioInfo.soundindex, timefromstart);
                         }
 
-                        if (pAudioInfo.soundindex != -1)
+                        if (pAudioInfo.soundindex != -1 && audio_emitter_exists(pAudioInfo.emitterindex) === true)
                         {
                             audio_emitter_gain(pAudioInfo.emitterindex, gain);
                             audio_emitter_pitch(pAudioInfo.emitterindex, pitch);
@@ -5525,7 +5525,7 @@ CSequenceInstance.prototype.SetupAudioEmitters = function (_tracks)
                             {
                                 // Create an audio emitter
                                 var emitter = audio_emitter_create();
-                                if ((emitter != undefined) && (emitter != -1))
+                                if (audio_emitter_exists(emitter) === true)
                                 {
                                     var newAudioInfo = new CSeqTrackAudioInfo();
                                     newAudioInfo.emitterindex = emitter;
@@ -5632,7 +5632,7 @@ CSequenceInstance.prototype.CleanupAudioEmitters = function ()
         {
             var pInfo = this.trackAudio[key];
 
-            if ((pInfo.emitterindex != undefined) && (pInfo.emitterindex >= 0))
+            if (audio_emitter_exists(pInfo.emitterindex) === true)
             {
                 audio_stop_sound(pInfo.soundindex);
                 audio_emitter_free(pInfo.emitterindex);


### PR DESCRIPTION
We recently started throwing from emitter functions if the emitter index passed in is invalid, so we should take extra care that the emitters that we use internally do not cause an exception to be thrown.

These changes just call `audio_emitter_exists` on the emitter index held by a sequence track info to check whether it is valid (both exists and is active) before calling any other emitter functions with it.

Other changes:
- Specifies that the emitter causing the error is in fact an audio emitter.
- Adds an explicit case for `undefined` emitter indices in `audio_emitter_exists` as that value can now be returned from `audio_emitter_create`.

Other side to this: https://github.com/YoYoGames/GameMaker/pull/1865