### PR TITLE
GM-6468: Fixed draw_text* functions ignorig sprite origin when using font_add_sprite

### DIFF
--- a/scripts/functions/Function_Font.js
+++ b/scripts/functions/Function_Font.js
@@ -96,10 +96,10 @@ function draw_text_color(_x, _y, _text, _c1, _c2, _c3, _c4, _alpha)
 	    _alpha = 0.0;
 
 	var a = ((yyGetReal(_alpha) * 255) << 24)&0xff000000;
-	_c1 = (yyGetInt32(_c1) & 0xffffff) | a;
-	_c2 = (yyGetInt32(_c2) & 0xffffff) | a;
-	_c3 = (yyGetInt32(_c3) & 0xffffff) | a;
-	_c4 = (yyGetInt32(_c4) & 0xffffff) | a;
+	_c1 = ConvertGMColour(yyGetInt32(_c1) & 0xffffff) | a;
+	_c2 = ConvertGMColour(yyGetInt32(_c2) & 0xffffff) | a;
+	_c3 = ConvertGMColour(yyGetInt32(_c3) & 0xffffff) | a;
+	_c4 = ConvertGMColour(yyGetInt32(_c4) & 0xffffff) | a;
 
 	g_pFontManager.GR_Text_Draw(yyGetString(_text), yyGetReal(_x), yyGetReal(_y), -1, -1, 0, 1, 1, _c1, _c2, _c3, _c4);
 	
@@ -141,10 +141,10 @@ function draw_text_ext_color(_x, _y, _text, _sep, _w, _c1, _c2, _c3, _c4, _alpha
 	    _alpha = 0.0;
 
 	var a = (yyGetReal(_alpha) * 255)<<24;
-	_c1 = (yyGetInt32(_c1) & 0xffffff) | a;
-	_c2 = (yyGetInt32(_c2) & 0xffffff) | a;
-	_c3 = (yyGetInt32(_c3) & 0xffffff) | a;
-	_c4 = (yyGetInt32(_c4) & 0xffffff) | a;
+	_c1 = ConvertGMColour(yyGetInt32(_c1) & 0xffffff) | a;
+	_c2 = ConvertGMColour(yyGetInt32(_c2) & 0xffffff) | a;
+	_c3 = ConvertGMColour(yyGetInt32(_c3) & 0xffffff) | a;
+	_c4 = ConvertGMColour(yyGetInt32(_c4) & 0xffffff) | a;
 
 	g_pFontManager.GR_Text_Draw(yyGetString(_text), yyGetReal(_x), yyGetReal(_y), yyGetInt32(_sep), yyGetInt32(_w), 0, 1, 1, _c1, _c2, _c3, _c4);
 

--- a/scripts/yyFont.js
+++ b/scripts/yyFont.js
@@ -953,7 +953,7 @@ yyFont.prototype.Draw_String = function (_x, _y, _pStr, _xscale, _yscale, _angle
 ///				
 ///			 </returns>
 // #############################################################################################
-yyFont.prototype.Draw_Sprite_String = function (_x, _y, _pStr, _xscale, _yscale, _angle, _col1, _col2, _col3, _col4, _charSpacing, wordSpacing)
+yyFont.prototype.Draw_Sprite_String = function (_x, _y, _pStr, _xscale, _yscale, _angle, _col1, _col2, _col3, _col4, _charSpacing, _wordSpacing)
 {
 	if (this.pSprites == null) return;
 
@@ -997,8 +997,8 @@ yyFont.prototype.Draw_Sprite_String = function (_x, _y, _pStr, _xscale, _yscale,
 		            var TP = g_Textures[pTPE.tp]; 		        // get texture page
 		            if (TP.complete)							// make sure texture has loaded
 		            {
-		                var ox = pTPE.XOffset + this.pSprites.xOrigin;
-		                var oy = pTPE.YOffset + this.pSprites.yOrigin;
+		                var ox = pTPE.XOffset - this.pSprites.xOrigin;
+		                var oy = pTPE.YOffset - this.pSprites.yOrigin;
 		                if (this.prop) ox = 0;
 
 		                // If coloured, then cache a "colourised" version
@@ -1122,8 +1122,8 @@ yyFont.prototype.Draw_Sprite_String_GL = function (_x, _y, _pStr, _xscale, _ysca
 		            var TP = g_Textures[pTPE.tp]; 				// get texture page
 		            if (TP.complete)							// make sure texture has loaded
 		            {
-		                var ox = pTPE.XOffset + this.pSprites.xOrigin;
-		                var oy = pTPE.YOffset + this.pSprites.yOrigin;
+		                var ox = pTPE.XOffset - this.pSprites.xOrigin;
+		                var oy = pTPE.YOffset - this.pSprites.yOrigin;
 		                if (this.prop) ox = 0;
 
 		                graphics._drawImage(pTPE, pTPE.x, pTPE.y, pTPE.w, pTPE.h, _x + (ox * xsc), _y + (oy * ysc), pTPE.CropWidth * xsc, pTPE.CropHeight * ysc, c1, c2, c3, c4);
@@ -1948,12 +1948,6 @@ yyFontManager.prototype.GR_Text_Draw = function (_str, x, y, linesep, linewidth,
 			{				
 			    if (this.halign == 1) xoff = -(xscale * thefont.TextWidth(pStr, true) / 2);
 			    if (this.halign == 2) xoff = -(xscale * thefont.TextWidth(pStr, true));
-				
-				// Adjust offsets to allow for the (x,y) origin of sprite fonts
-				if (thefont.spritefont) {
-				    xoff -= (xscale * thefont.pSprites.xOrigin);
-				    yoff -= (yscale * thefont.pSprites.yOrigin);
-				}
 
 				var xx = x + (cc * xoff) + (ss * yoff);
 				var yy = y - (ss * xoff) + (cc * yoff);


### PR DESCRIPTION
Also fixes `*_color` variants when WebGL is disabled in HTML5 options.