### PR TITLE
[Xor filters] Various fixes to support new Xor filters\effects

### DIFF
--- a/scripts/CameraManager.js
+++ b/scripts/CameraManager.js
@@ -806,6 +806,51 @@ function camera_apply(arg0) {
     }
 }
 
+function camera_copy_transforms(arg0,arg1) {
+    var dest = g_pCameraManager.GetCamera(yyGetInt32(arg0));
+    var src = g_pCameraManager.GetCamera(yyGetInt32(arg1));
+
+    if (dest == null)
+    {
+        dbg_csol.Output("camera_copy_settings() - camera to copy to doesn't exist\n");
+        return;
+    }
+    if (src == null)
+    {
+        dbg_csol.Output("camera_copy_settings() - camera to copy from doesn't exist\n");
+        return;
+    }
+    if (src == dest)
+    {
+        dbg_csol.Output("camera_copy_settings() - source and destination cameras are the same\n");
+		return;
+    }
+
+    // copy all values
+    dest.m_viewX = src.m_viewX;
+    dest.m_viewY = src.m_viewY;
+    dest.m_viewWidth = src.m_viewWidth;
+    dest.m_viewHeight = src.m_viewHeight;
+    dest.m_viewSpeedX = src.m_viewSpeedX;
+    dest.m_viewSpeedY = src.m_viewSpeedY;
+    dest.m_viewBorderX = src.m_viewBorderX;
+    dest.m_viewBorderY = src.m_viewBorderY;
+    dest.m_viewAngle = src.m_viewAngle;    
+
+    var viewmat = new Matrix(src.m_viewMat);
+    var projmat = new Matrix(src.m_projMat);
+    var viewProjMat = new Matrix(src.m_viewProjMat);
+    var invProjMat = new Matrix(src.m_invProjMat);
+    var invViewMat = new Matrix(src.m_invViewMat);
+    var invViewProjMat = new Matrix(src.m_invViewProjMat);
+    dest.m_projMat = projmat;
+    dest.m_viewMat = viewmat;
+    dest.m_viewProjMat = viewProjMat;
+    dest.m_invProjMat = invProjMat;
+    dest.m_invViewMat = invViewMat;
+    dest.m_invViewProjMat = invViewProjMat;    
+}
+
 function camera_get_active() {
     var cam = g_pCameraManager.GetActiveCamera();
     if (cam != null)

--- a/scripts/functions/Function_Surface.js
+++ b/scripts/functions/Function_Surface.js
@@ -447,22 +447,60 @@ function surface_set_target_RELEASE(_id)
     {
         if (!g_webGL) Graphics_Save();
 
-        g_SurfaceStack.push({
-            FrameBuffer: g_CurrentFrameBuffer,
-            RenderTargetActive: g_RenderTargetActive,
+        var currcam = g_pCameraManager.GetActiveCamera();
+        
+        if (currcam != null)
+        {
+            g_SurfaceStack.push({
+                FrameBuffer: g_CurrentFrameBuffer,
+                RenderTargetActive: g_RenderTargetActive,                
 
-            viewportx: g_clipx,
-            viewporty: g_clipy,
-            viewportw: g_clipw,
-            viewporth: g_cliph,
+                viewportx: g_clipx,
+                viewporty: g_clipy,
+                viewportw: g_clipw,
+                viewporth: g_cliph,
 
-            worldx: g_worldx,
-            worldy: g_worldy,
-            worldw: g_worldw,
-            worldh: g_worldh,
+                worldx: g_worldx,
+                worldy: g_worldy,
+                worldw: g_worldw,
+                worldh: g_worldh,                
 
-            cannvas_graphics: graphics,
-        });
+                cannvas_graphics: graphics,
+
+                ActiveCam: true,
+
+                camx: currcam.m_viewX,
+                camy: currcam.m_viewY,
+                camw: currcam.m_viewWidth,
+                camh: currcam.m_viewHeight,
+
+                cama: currcam.m_viewAngle,
+
+                camviewmat: new Matrix(currcam.m_viewMat),
+                camprojmat: new Matrix(currcam.m_projMat),
+            });
+        }
+        else
+        {
+            g_SurfaceStack.push({
+                FrameBuffer: g_CurrentFrameBuffer,
+                RenderTargetActive: g_RenderTargetActive,                
+
+                viewportx: g_clipx,
+                viewporty: g_clipy,
+                viewportw: g_clipw,
+                viewporth: g_cliph,
+
+                worldx: g_worldx,
+                worldy: g_worldy,
+                worldw: g_worldw,
+                worldh: g_worldh,
+
+                cannvas_graphics: graphics,
+
+                ActiveCam: false,
+            });
+        }
         g_CurrentSurfaceIdStack.push(g_CurrentSurfaceId);
         g_CurrentSurfaceId = _id;
 
@@ -531,6 +569,20 @@ function surface_reset_target_RELEASE()
         g_worldw = storedState.worldw;
         g_worldh = storedState.worldh;
 
+        var activeCam = storedState.ActiveCam;
+        var camx, camy, camw, camh, cama, camviewmat, camprojmat;
+
+        if (activeCam == true)
+        {
+            camx = storedState.camx;
+            camy = storedState.camy;
+            camw = storedState.camw;
+            camh = storedState.camh;
+            cama = storedState.cama;
+            camviewmat = storedState.camviewmat;
+            camprojmat = storedState.camprojmat;
+        }
+
         if (!g_webGL) {
             graphics = storedState.cannvas_graphics;
             Graphics_Restore();
@@ -547,7 +599,18 @@ function surface_reset_target_RELEASE()
         } else {
             Graphics_SetViewPort(g_clipx, g_clipy, g_clipw, g_cliph);
             if (g_isZeus) {
-                UpdateDefaultCamera(g_worldx, g_worldy, g_worldw, g_worldh, 0);
+                var currcam = g_pCameraManager.GetActiveCamera();
+                if ((activeCam == true) && (currcam != null))
+                {
+                    UpdateCamera(camx, camy, camw, camh, cama, currcam);
+                    currcam.SetViewMat(new Matrix(camviewmat));
+                    currcam.SetProjMat(new Matrix(camprojmat));
+                    currcam.ApplyMatrices();
+                }
+                else
+                {
+                    UpdateDefaultCamera(g_worldx, g_worldy, g_worldw, g_worldh, 0);
+                }
             }
             else {
                 Graphics_SetViewArea(g_worldx, g_worldy, g_worldw, g_worldh, 0);

--- a/scripts/yyEffects.js
+++ b/scripts/yyEffects.js
@@ -292,10 +292,7 @@ function yyFilterHost(_pShader, _shaderId, _pEffectInfo)
 	}
 	this[funcId] = this.RoomEnd;
 
-	var varId = "gml" + EFFECT_AFFECT_SINGLE_LAYER_VAR;
-	if ((typeof g_var2obf !== "undefined") && (g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR] != undefined)) {
-		varId = g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR];
-	}
+	var varId = EFFECT_AFFECT_SINGLE_LAYER_VAR;
 	this[varId] = false;		// set this to false initially
 
 	this.GetCommonShaderConstants();
@@ -346,10 +343,7 @@ yyFilterHost.prototype.LayerBegin = function (_layerID)
 	
 	// Check to see if this filter should apply only to this layer
 	var bOnlyThisLayer = false;
-	var varId = "gml" + EFFECT_AFFECT_SINGLE_LAYER_VAR;
-	if ((typeof g_var2obf !== "undefined") && (g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR] != undefined)) {
-		varId = g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR];
-	}
+	var varId = EFFECT_AFFECT_SINGLE_LAYER_VAR;
 	var pVar = this[varId];
 	if (pVar !== undefined)	
 	{
@@ -1150,11 +1144,7 @@ yyEffectsManager.prototype.CreateNewEffectInstance = function (_effectname, _aut
 		newEffect.SetDefaultValues();
 
 		var bAffectsSingleLayerOnly = false;
-		var varId = "gml" + EFFECT_AFFECT_SINGLE_LAYER_VAR;
-		if ((typeof g_var2obf !== "undefined") && (g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR] != undefined)) {
-			varId = g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR];
-		}
-		newEffect[varId] = bAffectsSingleLayerOnly;
+		newEffect.SetParam(EFFECT_AFFECT_SINGLE_LAYER_VAR, FAE_PARAM_BOOL, 1, [ bAffectsSingleLayerOnly ]);		// hard code this just now
 
 		return newEffect;
 	}
@@ -1234,12 +1224,8 @@ yyEffectsManager.prototype.SetupLayerEffect = function (_pRoom, _pLayer)
 				var pParam = pEffectInfo.pParams[i]; //CLayerEffectParam
 				pEffectInst.SetParam(pParam.pName, pParam.type, pParam.elements, pParam.defaults_data);
 			}
-
-			var varId = "gml" + EFFECT_AFFECT_SINGLE_LAYER_VAR;
-			if ((typeof g_var2obf !== "undefined") && (g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR] != undefined)) {
-				varId = g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR];
-			}			
-			pEffectInst.SetParam(varId, FAE_PARAM_BOOL, 1, [ pEffectInfo.bAffectsSingleLayerOnly ]);
+		
+			pEffectInst.SetParam(EFFECT_AFFECT_SINGLE_LAYER_VAR, FAE_PARAM_BOOL, 1, [ pEffectInfo.bAffectsSingleLayerOnly ]);
 		}
 	}
 	else
@@ -1265,11 +1251,7 @@ yyEffectsManager.prototype.SetupLayerEffect = function (_pRoom, _pLayer)
 					_pLayer.SetEffect(pEffectInst.GetRef());
 					_pRoom.AddEffectLayerID(_pLayer.m_id);
 
-					var varId = "gml" + EFFECT_AFFECT_SINGLE_LAYER_VAR;
-					if ((typeof g_var2obf !== "undefined") && (g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR] != undefined)) {
-						varId = g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR];
-					}
-					pEffectInst.SetParam(varId, FAE_PARAM_BOOL, 1, [ false ]);		// hard code this just now
+					pEffectInst.SetParam(EFFECT_AFFECT_SINGLE_LAYER_VAR, FAE_PARAM_BOOL, 1, [ false ]);		// hard code this just now
 				}
 			}
 		}


### PR DESCRIPTION
- Restore previous camera transforms when calling surface_reset_target() in the same way as the C++ runner
- Add support for camera_copy_transforms() GML function
- Fixed effects not being passed the single layer flag properly