### PR TITLE
GM-7163: Refactor audio_sound_gain

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -805,6 +805,9 @@ audioSound.prototype.throwOnEndedEvent = function(_wasStopped) {
 function ClampAndWarn(_val, _lo, _hi, _fn, _arg) {
     let newVal = _val;
 
+    if (isNaN(newVal) === true)
+        newVal = 0.0;
+
     if (isNaN(_lo) === false)
         newVal = Math.max(_lo, newVal);
 


### PR DESCRIPTION
- Encapsulates voice gain setting in `audioSound.prototype.setGain`.
- Encapsulates voice gain-node updating in `audioSound.prototype.updateGain`.
    - This is now called from `audio_update`.
- Fixes a bug in `audio_sound_gain` where the return value of `Audio_GetSound` was compared to `undefined` instead of `null`.
- Adds the function `ClampAndWarn` which will print a console warning if the value passed in was clamped.