### PR TITLE
GM-7149: Added new particle_get_info function

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -35,7 +35,7 @@ function particle_get_info(_ind)
         variable_struct_set(pPSI, "name", pPS.name);
         variable_struct_set(pPSI, "xorigin", pPS.originX);
         variable_struct_set(pPSI, "yorigin", pPS.originY);
-        variable_struct_set(pPSI, "draw_order", pPS.drawOrder);
+        variable_struct_set(pPSI, "oldtonew", (pPS.drawOrder == 0));
 
         var emittersArray = [];
         for (var i = 0; i < pPS.emitters.length; ++i)

--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -15,8 +15,100 @@
 // 
 // **********************************************************************************************************************
 
+// #############################################################################################
+/// Function:<summary>
+///          </summary>
+///
+/// In:		<param name="_ind"></param>
+/// Out:	<returns>
+///			</returns>
+// #############################################################################################
+function particle_get_info(_ind)
+{
+    _ind = yyGetInt32(_ind);
+    var pPS = CParticleSystem.Get(_ind);
+    var pPSI = undefined;
+    if (pPS != null)
+    {
+        pPSI = new GMLObject();
 
+        variable_struct_set(pPSI, "name", pPS.name);
+        variable_struct_set(pPSI, "xorigin", pPS.originX);
+        variable_struct_set(pPSI, "yorigin", pPS.originY);
+        variable_struct_set(pPSI, "draw_order", pPS.drawOrder);
 
+        var emittersArray = [];
+        for (var i = 0; i < pPS.emitters.length; ++i)
+        {
+            var emitterIndex = pPS.emitters[i];
+            var templateEmitter = g_PSEmitters[emitterIndex];
+
+            var pEmitterI = new GMLObject();
+
+            variable_struct_set(pEmitterI, "name", templateEmitter.name);
+            variable_struct_set(pEmitterI, "mode", templateEmitter.mode);
+            variable_struct_set(pEmitterI, "number", templateEmitter.number);
+            variable_struct_set(pEmitterI, "xmin", templateEmitter.xmin);
+            variable_struct_set(pEmitterI, "xmax", templateEmitter.xmax);
+            variable_struct_set(pEmitterI, "ymin", templateEmitter.ymin);
+            variable_struct_set(pEmitterI, "ymax", templateEmitter.ymax);
+            variable_struct_set(pEmitterI, "distribution", templateEmitter.posdistr);
+            variable_struct_set(pEmitterI, "shape", templateEmitter.shape);
+
+            var pPartTypeI = new GMLObject();
+            var particleType = g_ParticleTypes[templateEmitter.parttype];
+
+            variable_struct_set(pPartTypeI, "ind", templateEmitter.parttype);
+            variable_struct_set(pPartTypeI, "sprite", particleType.sprite);
+            variable_struct_set(pPartTypeI, "frame", particleType.spritestart);
+            variable_struct_set(pPartTypeI, "animate", particleType.spriteanim);
+            variable_struct_set(pPartTypeI, "stretch", particleType.spritestretch);
+            variable_struct_set(pPartTypeI, "random", particleType.spriterandom);
+            variable_struct_set(pPartTypeI, "shape", particleType.shape);
+            variable_struct_set(pPartTypeI, "size_min", particleType.sizemin);
+            variable_struct_set(pPartTypeI, "size_max", particleType.sizemax);
+            variable_struct_set(pPartTypeI, "size_incr", particleType.sizeincr);
+            variable_struct_set(pPartTypeI, "size_wiggle", particleType.sizerand);
+            variable_struct_set(pPartTypeI, "xscale", particleType.xscale);
+            variable_struct_set(pPartTypeI, "yscale", particleType.yscale);
+            variable_struct_set(pPartTypeI, "life_min", particleType.lifemin);
+            variable_struct_set(pPartTypeI, "life_max", particleType.lifemax);
+            variable_struct_set(pPartTypeI, "death_type", particleType.deathtype);
+            variable_struct_set(pPartTypeI, "death_number", particleType.deathnumber);
+            variable_struct_set(pPartTypeI, "step_type", particleType.steptype);
+            variable_struct_set(pPartTypeI, "step_number", particleType.stepnumber);
+            variable_struct_set(pPartTypeI, "speed_min", particleType.spmin);
+            variable_struct_set(pPartTypeI, "speed_max", particleType.spmax);
+            variable_struct_set(pPartTypeI, "speed_incr", particleType.spincr);
+            variable_struct_set(pPartTypeI, "speed_wiggle", particleType.sprand);
+            variable_struct_set(pPartTypeI, "dir_min", particleType.dirmin);
+            variable_struct_set(pPartTypeI, "dir_max", particleType.dirmax);
+            variable_struct_set(pPartTypeI, "dir_incr", particleType.dirincr);
+            variable_struct_set(pPartTypeI, "dir_wiggle", particleType.dirrand);
+            variable_struct_set(pPartTypeI, "grav_amount", particleType.grav);
+            variable_struct_set(pPartTypeI, "grav_dir", particleType.gravdir);
+            variable_struct_set(pPartTypeI, "ang_min", particleType.angmin);
+            variable_struct_set(pPartTypeI, "ang_max", particleType.angmax);
+            variable_struct_set(pPartTypeI, "ang_incr", particleType.angincr);
+            variable_struct_set(pPartTypeI, "ang_wiggle", particleType.angrand);
+            variable_struct_set(pPartTypeI, "ang_relative", particleType.angdir);
+            // variable_struct_set(pPartTypeI, "color_mode", particleType.colmode);
+            variable_struct_set(pPartTypeI, "color1", particleType.colpar[0]);
+            variable_struct_set(pPartTypeI, "color2", particleType.colpar[1]);
+            variable_struct_set(pPartTypeI, "color3", particleType.colpar[2]);
+            variable_struct_set(pPartTypeI, "alpha1", particleType.alphastart);
+            variable_struct_set(pPartTypeI, "alpha2", particleType.alphamiddle);
+            variable_struct_set(pPartTypeI, "alpha3", particleType.alphaend);
+            variable_struct_set(pPartTypeI, "additive", particleType.additiveblend);
+
+            variable_struct_set(pEmitterI, "parttype", pPartTypeI);
+
+            emittersArray.push(pEmitterI);
+        }
+        variable_struct_set(pPSI, "emitters", emittersArray);
+    }
+    return pPSI;
+}
 
 // #############################################################################################
 /// Function:<summary>

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -158,6 +158,8 @@ function Emitter_Reset()
 
 	this.created = true;		// whether created
 
+	this.name = undefined;
+	
 	this.mode = PT_MODE_UNDEFINED;	// stream or burst
 	this.number = 0;				// number of particles to create
 
@@ -1312,7 +1314,7 @@ function ParticleSystem_Emitters_Load(_GameFile)
 		////////////////////////////////////////////////////////////////////////
 		// Emitter
 		var emitter = new yyEmitter();
-		// TODO: Use emitter name from YYPSEmitter
+		emitter.name = yypse.pName;
 		//emitter.enabled = yypse.enabled;
 		emitter.mode = yypse.mode;
 		emitter.number = yypse.emitCount;


### PR DESCRIPTION
* Added new function `particle_get_info(ind)`, which takes a particle system resource and returns a struct with its info.
* Added new constants `ps_mode_stream` and `ps_mode_burst`. Emitter info included in `particle_get_info`'s return value use these to tell whether they use a "stream" mode or a "burst" mode respectively.

# Particle system info struct
* `name` - The name of the particle system resource.
* `xorigin` - The X origin of the particle system.
* `yorigin` - The Y origin of the particle system.
* `oldtonew` - Whether old particles should be drawn behind new ones (`true`) or vice versa (`false`).
* `emitters` - An array of emitter info structs, ordered the same as in the Particle Editor.

# Emitter info struct
* `name` - The name of the emitter.
* `mode` - Either `ps_mode_stream` or `ps_mode_burst`.
* `number` - Number of particles to create each frame if `mode` is `ps_mode_stream` or to create only once if mode is `ps_mode_burst`.
* `xmin` - The X coordinate of the left side of the emitter's region.
* `xmax` - The X coordinate of the right side of the emitter's region.
* `ymin` - The Y coordinate of the top of the emitter's region.
* `ymax` - The Y coordinate of the bottom of the emitter's region.
* `distribution` - The distribution style of the particles. One of the `ps_distr_*` constants.
* `shape` - The shape of the emitter's region. One of the `ps_shape_*` constants.
* `parttype` - Particle type info struct.

# Particle type info struct
* `ind` - The index of the particle type. This can be used e.g. with function `part_particles_create`.
* `sprite` - The index of the sprite that the particle type uses or `-1`.
* `frame` - The sprite subimage.
* `animate` - If `true` then the sprite is animated, staring from the `frame` subimage.
* `stretch` - If `true` then the animation is stretched over the particle's lifetime.
* `random` - If `true` then a random subimage is used instead of `frame`.
* `shape` - The particle shape. One of the `pt_shape_*` constants. Used only if `sprite` is `-1`.
* `size_min` - The minimum size of the particle.
* `size_max` - The maximum size of the particle.
* `size_incr` - Value to increase/decrease the particle size by each frame.
* `size_wiggle` - Value randomly added or subtracted from the particle size each frame.
* `xscale` - The X scale of the particle image (sprite or shape).
* `yscale` - The Y scale of the particle image (sprite or shape).
* `life_min` - The minimum life of the particle (in number of frames).
* `life_max` - The maximum life of the particle (in number of frames).
* `death_type` - The type of the particle spawned on death or `-1`.
* `death_number` - Number of particles spawned on death.
* `step_type` - The type of the particle spawned each frame or `-1`.
* `step_number` - Number of particles spawned each frame.
* `speed_min` - The minimum speed of the particle when created (in pixels per frame).
* `speed_max` - The maximum speed of the particle when created (in pixels per frame).
* `speed_incr` - Value to increase/decrease the particle speed by each frame.
* `speed_wiggle` - Value randomly added or subtracted from the particle speed each frame.
* `dir_min` - The minimum direction of the particle when created( in degrees).
* `dir_max` - The maximum direction of the particle when created (in degrees).
* `dir_incr` - Value to increase/decrease the particle direction by each frame.
* `dir_wiggle` - Value randomly added or subtracted from the particle direction each frame.
* `grav_amount` - Amount of gravity applied to the particle each frame (in pixels per frame).
* `grav_dir` - The gravity direction.
* `ang_min` - The minimum starting angle of the particle sprite when created (in degrees).
* `ang_max` - The maximum starting angle of the particle sprite when created (in degrees).
* `ang_incr` - Value to increase/decrease the particle angle by each frame.
* `ang_wiggle` - Value randomly added or subtracted from the particle angle each frame.
* `ang_relative` - If `true` then the particle angle is relative to its direction.
* `color1` - The color of the particle when created.
* `color2` - The color of the particle when halfway through its lifespan.
* `color3` - The color of the particle at the end of its lifespan.
* `alpha1` - The alpha of the particle when created.
* `alpha2` - The alpha of the particle when halfway through its lifespan.
* `alpha3` - The alpha of the particle at the end of its lifespan.
* `additive` - If `true` then the particle is drawn with additive blend mode (`bm_add`).

----

Issue link: https://bugs.opera.com/browse/GM-7149