### PR TITLE
GM-7249: Fixed part_particles_create_color crash

### DIFF
--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -1659,7 +1659,7 @@ function ParticleSystem_Particles_Create(_ps, _x, _y, _parttype, _numb)
 function	ParticleSystem_Particles_Create_Color( _ps, _x, _y, _parttype, _col, _numb)
 {
     var em = (g_ParticleSystems[_ps].emitters.length == 0)
-		? ParticleSystem_Emitter_Create(ps)
+		? ParticleSystem_Emitter_Create(_ps)
 		: 0;
 
 	EmitParticles(_ps, em, _x, _y, _parttype, _numb, true, _col);


### PR DESCRIPTION
I had a wrong variable name here, `ps` instead of `_ps`, hence the crash 🤦 
