### PR TITLE
GM-7359: Fixed filter layers not working in HTML5

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -17,7 +17,8 @@ YYLayerType_Background=1,
 YYLayerType_Instance=2,
 YYLayerType_Asset=3,
 YYLayerType_Tile=4,
-YYLayerType_Effect=5;
+YYLayerType_Particle=5,
+YYLayerType_Effect=6;
 
 
 var	eLayerElementType_Undefined = 0,


### PR DESCRIPTION
This was due to the fact that I forgot to update the `YYLayerType_` enum in the HTML5 runner when working on the new particle system resources created with a Particle Editor. The layer type then wasn't properly recognized and variable `bAffectsSingleLayerOnly` wasn't set to `false`.

Issue link: https://bugs.opera.com/browse/GM-7359

