### PR TITLE
Fix _json_replacer returning incorrect value in arrays

### DIFF
--- a/scripts/functions/Function_File.js
+++ b/scripts/functions/Function_File.js
@@ -1294,7 +1294,7 @@ function _json_replacer(value)
 
 				// Remove the flag
 				g_ENCODE_VISITED_LIST.delete(value);
-				return value;
+				return ret;
 			}
 
 			// It's an object prepare to set internal values


### PR DESCRIPTION
Appears to resolve bug [#207926](https://help.yoyogames.com/hc/en-us/requests/207926), where a struct is incorrectly stringified when contained in an array. 