### PR TITLE
GM-7575: Audio worklet path fix

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -144,7 +144,7 @@ function Audio_Init()
         Audio_CreateMainBus();
     }
     else {
-        g_WebAudioContext.audioWorklet.addModule(g_RootDir + "/sound/worklets/audio-worklet.js")
+        g_WebAudioContext.audioWorklet.addModule(g_RootDir + "sound/worklets/audio-worklet.js")
         .then(() => {
             Audio_CreateMainBus();
         }).catch((_err) => {


### PR DESCRIPTION
Removed an unnecessary '/' from the audio worklet subpath, as the game directory path it is suffixed to ends with one itself.

Some filesystems do not tolerate the double slash and thus fail to load the worklet.