### PR TITLE
GM-7598: WebKit compatibility fixes

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -1181,7 +1181,7 @@ function audio_play_sound_common(_props) {
             // Intentional fall-through
         case AudioPlaybackType.POSITIONAL_EMITTER:
             voice.pemitter = _props.emitter;
-            voice.pgainnode.connect(voice.pemitter);
+            voice.pgainnode.connect(voice.pemitter.getInput());
             break;
         default:
             debug("Warning: Unknown audio playback type => " + _props.type);
@@ -1881,15 +1881,15 @@ function audio_falloff_set_model(_model)
 
     audio_emitters.filter(_emitter => _emitter.isActive() === true)
                   .forEach(_emitter => {
-                      _emitter.distanceModel = falloff_model;
+                      _emitter.pannerNode.distanceModel = falloff_model;
 
                       //set/restore rolloff factor
                       if (g_AudioFalloffModel == DistanceModels.AUDIO_FALLOFF_NONE) {
-                          _emitter.original_rolloffFactor = _emitter.rolloffFactor;
-                          _emitter.rolloffFactor = 0;
+                          _emitter.original_rolloffFactor = _emitter.pannerNode.rolloffFactor;
+                          _emitter.pannerNode.rolloffFactor = 0;
                       }
                       else if (_emitter.original_rolloffFactor !== undefined) {
-                          _emitter.rolloffFactor = _emitter.original_rolloffFactor;
+                          _emitter.pannerNode.rolloffFactor = _emitter.original_rolloffFactor;
                           _emitter.original_rolloffFactor = undefined;
                       }
                 });

--- a/scripts/sound/AudioEmitter.js
+++ b/scripts/sound/AudioEmitter.js
@@ -1,32 +1,39 @@
-class AudioEmitter extends PannerNode {
+class AudioEmitter {
     constructor() {
         if (Audio_IsMainBusInitialised() === false) {
             console.error("Cannot create audio emitters until audio engine is running - check audio_system_is_initialised()");
             return null;
         }
-
-        super(g_WebAudioContext);
-    
+        
         this.gainnode = new GainNode(g_WebAudioContext, { gain: 1.0 });
-        this.connect(this.gainnode);
+        this.pannerNode = AudioEmitter.createPannerNode();
+        this.pannerNode.connect(this.gainnode);
     
         this.reset();
     }
 }
 
+AudioEmitter.createPannerNode = function() {
+    if (PannerNode === undefined) {
+        return g_WebAudioContext.createPanner();
+    }
+
+    return new PannerNode();
+};
+
 AudioEmitter.prototype.reset = function() {
     this.setPosition(0.0, 0.0, 0.01); // why was 'z' not zero?
 
-    this.refDistance = 100.0;
-    this.maxDistance = 100000.0;
-    this.rolloffFactor = 1.0;
+    this.pannerNode.refDistance = 100.0;
+    this.pannerNode.maxDistance = 100000.0;
+    this.pannerNode.rolloffFactor = 1.0;
 
-    this.coneInnerAngle = 360.0;
-    this.coneOuterAngle = 0.0;
-    this.coneOuterGain = 0.0;
+    this.pannerNode.coneInnerAngle = 360.0;
+    this.pannerNode.coneOuterAngle = 0.0;
+    this.pannerNode.coneOuterGain = 0.0;
 
-    this.distanceModel = falloff_model;
-    this.panningModel = "equalpower";
+    this.pannerNode.distanceModel = falloff_model;
+    this.pannerNode.panningModel = "equalpower";
 
     this.gainnode.gain.value = 1.0;
 
@@ -37,13 +44,17 @@ AudioEmitter.prototype.reset = function() {
 
     if (g_AudioFalloffModel === DistanceModels.AUDIO_FALLOFF_NONE) {
         // Workaround for no falloff
-        this.rolloffFactor = 0.0; 
+        this.pannerNode.rolloffFactor = 0.0; 
 
         // Store this value so we can restore it if the falloff model changes later
         this.original_rolloffFactor = 1.0; 
     }
 
     this.active = true;
+};
+
+AudioEmitter.prototype.getInput = function() {
+    return this.pannerNode;
 };
 
 AudioEmitter.prototype.isActive = function() {
@@ -61,31 +72,31 @@ AudioEmitter.prototype.setBus = function(_bus) {
 };
 
 AudioEmitter.prototype.setFalloff = function(_falloffRef, _falloffMax, _falloffFactor) {
-    this.refDistance = _falloffRef;
-    this.maxDistance = _falloffMax;
-    this.rolloffFactor = _falloffFactor;
-    this.distanceModel = falloff_model;
+    this.pannerNode.refDistance = _falloffRef;
+    this.pannerNode.maxDistance = _falloffMax;
+    this.pannerNode.rolloffFactor = _falloffFactor;
+    this.pannerNode.distanceModel = falloff_model;
 
     if (g_AudioFalloffModel === DistanceModels.AUDIO_FALLOFF_NONE) {
-        this.original_rolloffFactor = this.rolloffFactor;
-        this.rolloffFactor = 0.0;
+        this.original_rolloffFactor = this.pannerNode.rolloffFactor;
+        this.pannerNode.rolloffFactor = 0.0;
     }
 };
 
 AudioEmitter.prototype.getPositionX = function() {
-    return this.positionX.value;
+    return this.pannerNode.positionX.value;
 };
 
 AudioEmitter.prototype.getPositionY = function() {
-    return this.positionY.value;
+    return this.pannerNode.positionY.value;
 };
 
 AudioEmitter.prototype.getPositionZ = function() {
-    return this.positionZ.value;
+    return this.pannerNode.positionZ.value;
 };
 
 AudioEmitter.prototype.setPosition = function(_x, _y, _z) {
-    this.positionX.value = _x;
-    this.positionY.value = _y;
-    this.positionZ.value = _z;
+    this.pannerNode.positionX.value = _x;
+    this.pannerNode.positionY.value = _y;
+    this.pannerNode.positionZ.value = _z;
 };

--- a/scripts/sound/AudioEmitter.js
+++ b/scripts/sound/AudioEmitter.js
@@ -18,7 +18,7 @@ AudioEmitter.createPannerNode = function() {
         return g_WebAudioContext.createPanner();
     }
 
-    return new PannerNode();
+    return new PannerNode(g_WebAudioContext);
 };
 
 AudioEmitter.prototype.reset = function() {

--- a/scripts/yyTime.js
+++ b/scripts/yyTime.js
@@ -51,8 +51,6 @@ function SecondsToMicros(_s)
 
 class CTimeSource
 {
-    static idCtr = 0; // ID counter - keeps track of given IDs
-
     /* Creates a time source with the given ID */
     constructor(_id)
     {
@@ -285,6 +283,8 @@ class CTimeSource
         return this.type;
     }
 }
+
+CTimeSource.idCtr = 0;
 
 /********** CStatefulTimeSource *********/
 


### PR DESCRIPTION
Addresses more issues raised in https://github.com/YoYoGames/GameMaker-HTML5/issues/192.

Changes:
- Avoids extending `PannerNode` from `AudioEmitter`.
- Avoids using the `static` keyword in `CTimeSource`.