### PR TITLE
Fix for GM-7626

### DIFF
--- a/scripts/libWebGL/libWebGL.js
+++ b/scripts/libWebGL/libWebGL.js
@@ -154,7 +154,7 @@ function yyWebGL(_canvas, _options) {
         g_extTextureFloatLinear = gl.getExtension('OES_texture_float_linear');
         g_extColourBufferFloat = gl.getExtension('EXT_color_buffer_float');
         
-        if (gl instanceof WebGL2RenderingContext)
+        if (!(typeof WebGL2RenderingContext === typeof undefined) && (gl instanceof WebGL2RenderingContext))        
         {
             g_isWebGL2 = true;
         }


### PR DESCRIPTION
Check whether WebGL2RenderingContext is a declared class before comparing our created GL instance to it to avoid an exception on Safari on iOS versions prior to 15. See https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext for further compatibility details.