### PR TITLE
Only use Spine collision mesh when selected (GM-6951).

### DIFF
--- a/scripts/functions/Function_Sprite.js
+++ b/scripts/functions/Function_Sprite.js
@@ -494,7 +494,7 @@ function sprite_create_from_surface_RELEASE(_id, _x, _y, _w, _h, _removeback, _s
 	pNewSpr.smooth = true;
 	pNewSpr.preload = true;
 	pNewSpr.bboxmode = 0;
-	pNewSpr.colcheck = false;
+	pNewSpr.colcheck = yySprite_CollisionType.AXIS_ALIGNED_RECT;
 	pNewSpr.xOrigin = _xorig;
 	pNewSpr.yOrigin = _yorig;
 
@@ -798,7 +798,7 @@ function sprite_add(_filename, _imgnumb, _removeback, _smooth, _xorig, _yorig, _
 	pNewSpr.smooth = yyGetBool(_smooth);
 	pNewSpr.preload = true;
 	pNewSpr.bboxmode = 0;
-	pNewSpr.colcheck = false;
+	pNewSpr.colcheck = yySprite_CollisionType.AXIS_ALIGNED_RECT;
 	pNewSpr.xOrigin = yyGetInt32(_xorig);
 	pNewSpr.yOrigin = yyGetInt32(_yorig);
 
@@ -923,7 +923,7 @@ function sprite_replace(_ind, _filename, _imgnumb, _removeback, _smooth, _xorig,
 	pNewSpr.smooth = yyGetBool(_smooth);
 	pNewSpr.preload = true;
 	pNewSpr.bboxmode = 0;
-	pNewSpr.colcheck = false;
+	pNewSpr.colcheck = yySprite_CollisionType.AXIS_ALIGNED_RECT;
 	pNewSpr.xOrigin = yyGetInt32(_xorig);
 	pNewSpr.yOrigin = yyGetInt32(_yorig);
 
@@ -1135,7 +1135,7 @@ function sprite_collision_mask( _ind, _sepmasks, _bbmode,_bbleft,_bbtop,_bbright
 {
     var pSpr = g_pSpriteManager.Get(yyGetInt32(_ind));        
     if( pSpr===null) { return false; }
-    pSpr.colcheck = true;
+    pSpr.colcheck = yySprite_CollisionType.PRECISE;
 
     // Clean up if required
     pSpr.colmask = [];
@@ -1783,7 +1783,7 @@ function sprite_get_info( _spriteIndex )
         variable_struct_set(ret, "num_subimages", pSpr.numb); //ret.gmlnum_subimages = pSpr.numb;
         variable_struct_set(ret, "frame_speed", (pSpr.playbackspeed != undefined) ? pSpr.playbackspeed : -1); //ret.gmlframe_speed = (pSpr.playbackspeed != undefined) ? pSpr.playbackspeed : -1;
         variable_struct_set(ret, "frame_type", (pSpr.playbackspeedtype != undefined) ? pSpr.playbackspeedtype : -1); //ret.gmlframe_type = (pSpr.playbackspeedtype != undefined) ? pSpr.playbackspeedtype : -1;
-        variable_struct_set(ret, "use_mask", pSpr.colcheck); //ret.gmluse_mask = pSpr.colcheck;
+        variable_struct_set(ret, "use_mask", pSpr.colcheck === yySprite_CollisionType.PRECISE); //ret.gmluse_mask = pSpr.colcheck;
         variable_struct_set(ret, "num_masks", pSpr.colmask.length); //ret.gmlnum_masks  = pSpr.colmask.length;
 
         switch( type ) {

--- a/scripts/yySprite.js
+++ b/scripts/yySprite.js
@@ -20,6 +20,17 @@ var ePlaybackSpeedType_FramesPerSecond = 0,
 
 var SKELETON_FRAMECOUNT = 2147483647;
 
+/**
+ * Type of collision check used for this sprite.
+ * Keep in sync with GMSprite::CollisionType in GMAssetCompiler.
+*/
+var yySprite_CollisionType = {
+	AXIS_ALIGNED_RECT: 0,  /**< Bounding box collision check. */
+	PRECISE: 1,            /**< Precise per-pixel collision check using mask. */
+	ROTATED_RECT: 2,       /**< Bounding box collision check (with rotation). */
+	SPINE_MESH: 3,         /**< Spine collision mesh check. */
+};
+
 // #############################################################################################
 /// Function:<summary>
 ///             simple rect
@@ -79,8 +90,7 @@ function    yySprite()
 	this.smooth = true;									// Whether to smooth the boundaries
 	this.preload = true;								// Whether to preload the texture
 	this.bboxmode = 0;									// Bounding box mode (0=automatic, 1=full, 2=manual)
-	this.colcheck = false;								// whether to prepare for precise collision checking
-	this.rotatedBounds = false;								// whether to prepare for precise collision checking
+	this.colcheck = yySprite_CollisionType.AXIS_ALIGNED_RECT;  // whether to prepare for precise collision checking
 	this.xOrigin = 0;								    //origin of the sprite
 	this.yOrigin = 0;
 	
@@ -102,7 +112,7 @@ function    yySprite()
 	this.m_LoadedFromChunk = false;
 	this.m_LoadedFromIncludedFiles = false;
 }
-yySprite.prototype.GetCollisionChecking = function () { return this.colcheck; };
+yySprite.prototype.GetCollisionChecking = function () { return this.colcheck === yySprite_CollisionType.PRECISE; };
 yySprite.prototype.GetXOrigin = function () { return this.xOrigin; };
 yySprite.prototype.GetYOrigin = function () { return this.yOrigin; };
 yySprite.prototype.GetBoundingBox = function () { return this.bbox; };
@@ -482,7 +492,7 @@ yySprite.prototype.BuildSWFData = function (_swfIndex, _xo, _yo) {
 					byteOffset = this.SetupSWFCollisionMasks(dataView, byteOffset, littleEndian);
 					
 					if (!this.m_LoadedFromChunk) {
-                        this.colcheck = true;
+                        this.colcheck = yySprite_CollisionType.PRECISE;
                     }
                 }
                 else {
@@ -490,7 +500,7 @@ yySprite.prototype.BuildSWFData = function (_swfIndex, _xo, _yo) {
                     this.height = this.SWFTimeline.maxY;
 
                     if (!this.m_LoadedFromChunk) {
-                        this.colcheck = false;
+                        this.colcheck = yySprite_CollisionType.AXIS_ALIGNED_RECT;
                     }
 				}
 				
@@ -500,7 +510,7 @@ yySprite.prototype.BuildSWFData = function (_swfIndex, _xo, _yo) {
 					this.preload = true;
 				}
                 
-                if (!this.m_LoadedFromChunk && !this.colcheck) {
+                if (!this.m_LoadedFromChunk && this.colcheck === yySprite_CollisionType.AXIS_ALIGNED_RECT) {
                     this.bbox.left = this.SWFTimeline.minX;
 		            this.bbox.right = this.SWFTimeline.maxX;
 		            this.bbox.top = this.SWFTimeline.minY;
@@ -527,7 +537,7 @@ yySprite.prototype.BuildSWFData = function (_swfIndex, _xo, _yo) {
 // #############################################################################################
 yySprite.prototype.SetupSWFCollisionMasks = function (_dataView, _byteOffset, _littleEndian) {
 
-    if (true != this.colcheck) {
+    if (this.colcheck !== yySprite_CollisionType.PRECISE) {
         return;
     }
 
@@ -877,8 +887,7 @@ function    CreateSpriteFromStorage( _pStore )
 	if( _pStore.smooth !== undefined ) pSprite.smooth = _pStore.smooth;									// Whether to smooth the boundaries
 	if( _pStore.preload !== undefined) pSprite.preload = _pStore.preload;								    // Whether to preload the texture
 	if( _pStore.bboxMode !== undefined ) pSprite.bboxmode = _pStore.bboxMode;									// Bounding box mode (0=automatic, 1=full, 2=manual)
-	if( _pStore.colCheck !== undefined ) pSprite.colcheck = _pStore.colCheck == 1;								// whether to prepare for precise collision checking
-	if( _pStore.colCheck !== undefined ) pSprite.rotatedBounds = _pStore.colCheck == 2;			// whether to prepare for rotated bounds checking
+	if( _pStore.colCheck !== undefined ) pSprite.colcheck = _pStore.colCheck;								// whether to prepare for precise collision checking
 	if( _pStore.xOrigin !== undefined ) pSprite.xOrigin = _pStore.xOrigin;								    //origin of the sprite
 	if( _pStore.yOrigin !== undefined ) pSprite.yOrigin = _pStore.yOrigin;	
 	
@@ -1435,7 +1444,7 @@ yySprite.prototype.PreciseCollision = function (_img1, _bb1, _x1, _y1, _scale1x,
 	var bottomedge = this.bbox.bottom + 1.0;
 
 
-	if (this.colcheck)
+	if (this.colcheck === yySprite.PRECISE)
 	{
 	    //If you have precise collisions you can't have collisions outside the texture - you can only do that with rectangle collisions where it is permissible to have i_bbox.left<0 etc
 	    if (leftedge < 0) 
@@ -1454,7 +1463,7 @@ yySprite.prototype.PreciseCollision = function (_img1, _bb1, _x1, _y1, _scale1x,
 	var stopedge = _pSpr.bbox.top;
 	var sbottomedge = _pSpr.bbox.bottom + 1.0;
 	var spr = _pSpr;
-	if (spr.colcheck)
+	if (spr.colcheck === yySprite.PRECISE)
 	{
 	    if (sleftedge < 0)
 	        sleftedge = 0;
@@ -1498,7 +1507,7 @@ yySprite.prototype.PreciseCollision = function (_img1, _bb1, _x1, _y1, _scale1x,
 			
 	        for (var j = t ; j < b; j += 1.0)
 	        {	
-	            if (this.colcheck)
+	            if (this.colcheck === yySprite_CollisionType.PRECISE)
 	            {
 
 	                var v1 = ((j - _y1) * _scale1y + this.yOrigin);
@@ -1509,7 +1518,7 @@ yySprite.prototype.PreciseCollision = function (_img1, _bb1, _x1, _y1, _scale1x,
 	                }
 	            }
 				
-	            if (spr.colcheck)
+	            if (spr.colcheck === yySprite_CollisionType.PRECISE)
 	            {
 	                var v2 = ((j - _y2) * _scale2y + spr.yOrigin);
 
@@ -1568,7 +1577,7 @@ yySprite.prototype.PreciseCollision = function (_img1, _bb1, _x1, _y1, _scale1x,
 	            }
 
 	            if ((v1 < topedge) || (v1 >= bottomedge)) continue;
-	            if (this.colcheck)
+	            if (this.colcheck === yySprite_CollisionType.PRECISE)
 	            {
 	                if (this.maskcreated) 
 	                {
@@ -1589,7 +1598,7 @@ yySprite.prototype.PreciseCollision = function (_img1, _bb1, _x1, _y1, _scale1x,
 
 				
 	            if ((v2 <stopedge) || (v2 >= sbottomedge)) continue;
-	            if (spr.colcheck)
+	            if (spr.colcheck === yySprite_CollisionType.PRECISE)
 	            {
 	                if (spr.maskcreated) 
 	                {

--- a/scripts/yyWebGL.js
+++ b/scripts/yyWebGL.js
@@ -4237,7 +4237,7 @@ function WebGL_sprite_create_from_surface_RELEASE(_id, _x, _y, _w, _h, _removeba
         pNewSpr.smooth = true;
         pNewSpr.preload = true;
         pNewSpr.bboxmode = 0;
-        pNewSpr.colcheck = false;
+        pNewSpr.colcheck = yySprite_CollisionType.AXIS_ALIGNED_RECT;
         pNewSpr.xOrigin = _xorig;
         pNewSpr.yOrigin = _yorig;
         pNewSpr.copy = true;


### PR DESCRIPTION
Historically, we would apply the bounding box and/or collision mask from the spine collision mesh or the precomputed mask from the sprite editor inconsistently in different code paths.

In the April (beta) this got changed to always use the Spine collision mesh, but then it was discovered people were relying on collisions defined in the sprite editor even though they did not apply well to all Spine sprites, so that change got backed out for the April stable.

This change adds a "Spine collision mesh" option to the sprite editor which allows for explicitly choosing to use Spine collision meshes OR GM collision masks in all cases on a per-sprite basis.