### PR TITLE
GM-7598: Webkit compatibility fixes

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -117,7 +117,7 @@ function audio_reinit()
 
     g_AudioMainVolumeNode.disconnect();
 
-    g_AudioMainVolumeNode = Audio_CreateGainNode(g_WebAudioContext);
+    g_AudioMainVolumeNode = g_WebAudioContext.createGain();
     g_AudioMainVolumeNode.connect(g_WebAudioContext.destination);
 
     g_WebAudioContext.listener.pos = new Vector3(0,0,0);
@@ -130,17 +130,23 @@ function Audio_Init()
     if (g_AudioModel !== Audio_WebAudio)
         return;
 
+    console.log("#1");
     const AudioContext = window.AudioContext || window.webkitAudioContext;
 
     g_WebAudioContext = new AudioContext();
+    console.log("#2");
     g_WebAudioContext.addEventListener("statechange", Audio_EngineReportState);
-
+    console.log("#2.1");
     g_HandleStreamedAudioAsUnstreamed = ( g_OSPlatform == BROWSER_IOS );
+    console.log("#2.2");
     g_UseDummyAudioBus = (g_OSBrowser === BROWSER_SAFARI_MOBILE)
                       || (g_WebAudioContext.audioWorklet === undefined);
-
-    g_AudioMainVolumeNode = Audio_CreateGainNode(g_WebAudioContext);
+    console.log("#2.3");
+    g_WebAudioContext.startRendering();
+    g_AudioMainVolumeNode = g_WebAudioContext.createGain();
+    console.log("#2.5");
     g_AudioMainVolumeNode.connect(g_WebAudioContext.destination);
+    console.log("#3");
 
     if (g_UseDummyAudioBus) {
         Audio_CreateMainBus();
@@ -153,6 +159,8 @@ function Audio_Init()
             console.error("Failed to load audio worklets => " + _err);
         });
     }
+
+    console.log("#4");
     
     audio_falloff_set_model(DistanceModels.AUDIO_FALLOFF_NONE);
 
@@ -184,7 +192,10 @@ function Audio_Init()
     Audio_InitSampleData();
     AudioGroups_Init();
 
+    console.log("#5");
+
     Audio_WebAudioContextTryUnlock();
+    console.log("#6");
 }
 
 function Audio_Quit()
@@ -204,7 +215,7 @@ function Audio_CreateGainNode(_context) {
         return new GainNode(_context);
     }
     else if (window.webkitAudioContext !== undefined && _context instanceof window.webkitAudioContext) {
-        return _context.createGain();
+        return undefined; //_context.createGain();
     }
 
     return undefined;

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -130,6 +130,8 @@ function Audio_Init()
     if (g_AudioModel !== Audio_WebAudio)
         return;
 
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+
     g_WebAudioContext = new AudioContext();
     g_WebAudioContext.addEventListener("statechange", Audio_EngineReportState);
 
@@ -922,7 +924,7 @@ var g_WaitingForWebAudioTouchUnlock = false;
 var g_HandleStreamedAudioAsUnstreamed = false;
 
 function Audio_ContextExists() {
-    return g_WebAudioContext instanceof AudioContext;
+    return g_WebAudioContext instanceof AudioContext || g_WebAudioContext instanceof webkitAudioContext;
 }
 
 function Audio_IsPlaybackAllowed() {

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -117,7 +117,7 @@ function audio_reinit()
 
     g_AudioMainVolumeNode.disconnect();
 
-    g_AudioMainVolumeNode = new GainNode(g_WebAudioContext);
+    g_AudioMainVolumeNode = Audio_CreateGainNode(g_WebAudioContext);
     g_AudioMainVolumeNode.connect(g_WebAudioContext.destination);
 
     g_WebAudioContext.listener.pos = new Vector3(0,0,0);
@@ -139,7 +139,7 @@ function Audio_Init()
     g_UseDummyAudioBus = (g_OSBrowser === BROWSER_SAFARI_MOBILE)
                       || (g_WebAudioContext.audioWorklet === undefined);
 
-    g_AudioMainVolumeNode = new GainNode(g_WebAudioContext);
+    g_AudioMainVolumeNode = Audio_CreateGainNode(g_WebAudioContext);
     g_AudioMainVolumeNode.connect(g_WebAudioContext.destination);
 
     if (g_UseDummyAudioBus) {
@@ -197,6 +197,17 @@ function Audio_Quit()
 	g_WebAudioContext.close().then(() => {
 		g_WebAudioContext = null;
 	});
+}
+
+function Audio_CreateGainNode(_context) {
+    if (window.AudioContext !== undefined && _context instanceof window.AudioContext) {
+        return new GainNode(_context);
+    }
+    else if (window.webkitAudioContext !== undefined && _context instanceof window.webkitAudioContext) {
+        return _context.createGain();
+    }
+
+    return undefined;
 }
 
 function Audio_GetBusType() {

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -117,7 +117,7 @@ function audio_reinit()
 
     g_AudioMainVolumeNode.disconnect();
 
-    g_AudioMainVolumeNode = g_WebAudioContext.createGain();
+    g_AudioMainVolumeNode = Audio_CreateGainNode(g_WebAudioContext);
     g_AudioMainVolumeNode.connect(g_WebAudioContext.destination);
 
     g_WebAudioContext.listener.pos = new Vector3(0,0,0);
@@ -130,23 +130,17 @@ function Audio_Init()
     if (g_AudioModel !== Audio_WebAudio)
         return;
 
-    console.log("#1");
     const AudioContext = window.AudioContext || window.webkitAudioContext;
 
     g_WebAudioContext = new AudioContext();
-    console.log("#2");
     g_WebAudioContext.addEventListener("statechange", Audio_EngineReportState);
-    console.log("#2.1");
+    
     g_HandleStreamedAudioAsUnstreamed = ( g_OSPlatform == BROWSER_IOS );
-    console.log("#2.2");
     g_UseDummyAudioBus = (g_OSBrowser === BROWSER_SAFARI_MOBILE)
                       || (g_WebAudioContext.audioWorklet === undefined);
-    console.log("#2.3");
-    g_WebAudioContext.startRendering();
-    g_AudioMainVolumeNode = g_WebAudioContext.createGain();
-    console.log("#2.5");
+    
+    g_AudioMainVolumeNode = Audio_CreateGainNode(g_WebAudioContext);
     g_AudioMainVolumeNode.connect(g_WebAudioContext.destination);
-    console.log("#3");
 
     if (g_UseDummyAudioBus) {
         Audio_CreateMainBus();
@@ -159,8 +153,6 @@ function Audio_Init()
             console.error("Failed to load audio worklets => " + _err);
         });
     }
-
-    console.log("#4");
     
     audio_falloff_set_model(DistanceModels.AUDIO_FALLOFF_NONE);
 
@@ -192,10 +184,7 @@ function Audio_Init()
     Audio_InitSampleData();
     AudioGroups_Init();
 
-    console.log("#5");
-
     Audio_WebAudioContextTryUnlock();
-    console.log("#6");
 }
 
 function Audio_Quit()
@@ -215,7 +204,7 @@ function Audio_CreateGainNode(_context) {
         return new GainNode(_context);
     }
     else if (window.webkitAudioContext !== undefined && _context instanceof window.webkitAudioContext) {
-        return undefined; //_context.createGain();
+        return _context.createGain();
     }
 
     return undefined;
@@ -314,7 +303,7 @@ audioSampleData.prototype.TryDecode = function ( _rawData, _processCommands )
 /** @constructor */
 function audioSound(_props)
 {
-    this.pgainnode = g_WebAudioContext.createGain();
+    this.pgainnode = Audio_CreateGainNode(g_WebAudioContext);
     this.pemitter = null;
     this.handle=0;
 
@@ -3601,7 +3590,7 @@ function audio_start_recording(_deviceNum)
                 {
                     var source = g_WebAudioContext.createMediaStreamSource(stream);
                     source.connect(gRecorder);
-                    var gainNode = g_WebAudioContext.createGain();
+                    var gainNode = Audio_CreateGainNode(g_WebAudioContext);
                     gRecorder.connect(gainNode);
                     gainNode.connect(g_WebAudioContext.destination);
                 },

--- a/scripts/sound/AudioBus.js
+++ b/scripts/sound/AudioBus.js
@@ -148,7 +148,7 @@ AudioBus.isNodeIndex = function(_prop)
 };
 
 function DummyAudioBus() {
-	this.outputNode = Audio_CreateGainNode(g_WebAudioContext);
+	this.outputNode = g_WebAudioContext.createGain();
 
 	this.bypass = false;
 	this.gain = 1.0;

--- a/scripts/sound/AudioBus.js
+++ b/scripts/sound/AudioBus.js
@@ -148,7 +148,7 @@ AudioBus.isNodeIndex = function(_prop)
 };
 
 function DummyAudioBus() {
-	this.outputNode = new GainNode(g_WebAudioContext);
+	this.outputNode = Audio_CreateGainNode(g_WebAudioContext);
 
 	this.bypass = false;
 	this.gain = 1.0;

--- a/scripts/sound/AudioBus.js
+++ b/scripts/sound/AudioBus.js
@@ -148,7 +148,7 @@ AudioBus.isNodeIndex = function(_prop)
 };
 
 function DummyAudioBus() {
-	this.outputNode = g_WebAudioContext.createGain();
+	this.outputNode = Audio_CreateGainNode(g_WebAudioContext);
 
 	this.bypass = false;
 	this.gain = 1.0;

--- a/scripts/sound/AudioEmitter.js
+++ b/scripts/sound/AudioEmitter.js
@@ -5,7 +5,7 @@ class AudioEmitter {
             return null;
         }
         
-        this.gainnode = Audio_CreateGainNode(g_WebAudioContext, { gain: 1.0 });
+        this.gainnode = g_WebAudioContext.createGain();
         this.pannerNode = AudioEmitter.createPannerNode();
         this.pannerNode.connect(this.gainnode);
     

--- a/scripts/sound/AudioEmitter.js
+++ b/scripts/sound/AudioEmitter.js
@@ -5,7 +5,7 @@ class AudioEmitter {
             return null;
         }
         
-        this.gainnode = g_WebAudioContext.createGain();
+        this.gainnode = Audio_CreateGainNode(g_WebAudioContext);
         this.pannerNode = AudioEmitter.createPannerNode();
         this.pannerNode.connect(this.gainnode);
     

--- a/scripts/sound/AudioEmitter.js
+++ b/scripts/sound/AudioEmitter.js
@@ -5,7 +5,7 @@ class AudioEmitter {
             return null;
         }
         
-        this.gainnode = new GainNode(g_WebAudioContext, { gain: 1.0 });
+        this.gainnode = Audio_CreateGainNode(g_WebAudioContext, { gain: 1.0 });
         this.pannerNode = AudioEmitter.createPannerNode();
         this.pannerNode.connect(this.gainnode);
     


### PR DESCRIPTION
Addresses more issues highlighted by https://github.com/YoYoGames/GameMaker-HTML5/issues/192:
- Instantiates `webkitAudioContext` in browsers where `AudioContext` is undefined.
- Adds `Audio_CreateGainNode`, which will create gain nodes for either kind of audio context.