### PR TITLE
GM-7577: Keep alive particles on part_emitter_destroy

### DIFF
--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -5018,11 +5018,14 @@ yySequenceManager.prototype.HandleParticleTrackUpdate = function (_pEl, _pSeq, _
                 {
                     for (var i = 0; i < pEmitters.length; i++)
                     {
-                        if( pEmitters[i]!=null
-                            && pEmitters[i].mode == PT_MODE_BURST
-                            && pEmitters[i].number != 0)
+                        var emitter = pEmitters[i];
+                        if (!emitter.enabled) continue;
+
+                        if (emitter.created
+                            && emitter.mode == PT_MODE_BURST
+                            && emitter.number != 0)
                         {
-                            ParticleSystem_Emitter_Burst(ps, i, pEmitters[i].parttype, pEmitters[i].number);
+                            ParticleSystem_Emitter_Burst(ps, i, emitter.parttype, emitter.number);
                         }
                     }
                 }


### PR DESCRIPTION
This behavior was accidentally changed when Particle Editor was added and we started sorting particles by type (/ by emitter that created them). To fix this issue, I've added a new property `zombie` to emitters, which is set to `true` when an emitter is destroyed and the emitter cannot be reused as long as the value isn't set back to `false`, which happens when all its particles die. This also required to match the JS code with the C++ code - instead of deleting emitters by setting them to `null`, we are setting their `created` property to `false`.

Issue link: https://bugs.opera.com/browse/GM-7577
