### PR TITLE
Fix crash when passing non-existant header map to http_request() (GM-7653).

### DIFF
--- a/scripts/functions/Function_HTTP.js
+++ b/scripts/functions/Function_HTTP.js
@@ -430,12 +430,14 @@ function http_request(_url, _method, _headerMap, _body)
 
     // Turn the supplied header ds_map into a set of key-value pairs
     var headers = [];
-    var pMap = g_ActiveMaps.Get(_headerMap);    
-    for (const [key, item] of pMap) {    
-        var v = key;
-        if (pMap.originalKeys && pMap.originalKeys.has(key))
-            v = pMap.originalKeys.get(key);        	
-	    headers.push({ key: v, value: item  });
+    var pMap = g_ActiveMaps.Get(_headerMap);
+    if (pMap !== null) {
+        for (const [key, item] of pMap) {
+            var v = key;
+            if (pMap.originalKeys && pMap.originalKeys.has(key))
+                v = pMap.originalKeys.get(key);
+            headers.push({ key: v, value: item  });
+        }
     }
     // If the "_body" is a number then it's an index to a binary buffer
     if (typeof(_body) === 'number') {


### PR DESCRIPTION
Arguably we should error if a positive-but-non-existant map is specified, but this matches the behaviour of the C++ runner.