### PR TITLE
GM-5979: Fixed projection not kept when using effect layers

### DIFF
--- a/scripts/CameraManager.js
+++ b/scripts/CameraManager.js
@@ -21,6 +21,7 @@ function CameraManager() {
     this.camId = 0;
     this.m_activeCamera = null;
     this.m_CamPool = new yyList();
+    this.m_tempCamera = null;
 };
 
 
@@ -194,6 +195,8 @@ CameraManager.prototype.DestroyCamera = function (camid) {
         var pCam = this.m_CamPool.Get(i);
         if (pCam) {
             if (pCam.m_id === camid) {
+                if (this.m_tempCamera == pCam)
+                    this.m_tempCamera = null;
                 this.m_CamPool.DeleteItem(pCam);
                 return;
             }
@@ -278,7 +281,7 @@ CameraManager.prototype.Clean = function () {
     this.m_activeCamera = null;
     this.m_cameraListCurr = 0;
     this.m_lastCamPos = 0;
-
+    this.m_tempCamera = null;
 };
 
 // ################################################################################################
@@ -286,6 +289,12 @@ CameraManager.prototype.Clean = function () {
 // ################################################################################################
 CameraManager.prototype.GetActiveCamera = function () {
     return this.m_activeCamera;
+};
+
+CameraManager.prototype.GetTempCamera = function () {
+    if (this.m_tempCamera == null)
+        this.m_tempCamera = this.GetCamera(this.CreateCamera());
+    return this.m_tempCamera;
 };
 
 CameraManager.prototype.SetActiveCamera = function (arg0) {

--- a/scripts/Globals.js
+++ b/scripts/Globals.js
@@ -1148,7 +1148,6 @@ function    InitAboyneGlobals() {
     g_OldView_Surface = new yyView();
     g_OldView_Surface_From = new yyView();
     g_DefaultView = new yyView();
-    g_DefaultView.cameraID=0; //Point to the default camera
     g_GUIView = new yyView();   
     g_pCurrentView = new yyView();
 

--- a/scripts/functions/Function_Surface.js
+++ b/scripts/functions/Function_Surface.js
@@ -523,7 +523,7 @@ function surface_set_target_RELEASE(_id)
         Graphics_SetViewPort(0, 0, pSurf.m_Width, pSurf.m_Height);
 
         if (g_isZeus) {
-            UpdateDefaultCamera(0, 0, pSurf.m_Width, pSurf.m_Height, 0);
+            UpdateTempCamera(0, 0, pSurf.m_Width, pSurf.m_Height, 0);
         }
         else {
             Graphics_SetViewArea(0, 0, pSurf.m_Width, pSurf.m_Height, 0);

--- a/scripts/yyEffects.js
+++ b/scripts/yyEffects.js
@@ -364,24 +364,17 @@ yyFilterHost.prototype.LayerBegin = function (_layerID)
 
 		this.tempSurfaceID = g_pEffectsManager.AcquireTempSurface(surfwidth, surfheight);
 
-		var pCam = g_pCameraManager.GetActiveCamera();
-		var pClonedCam = null;
-		if (pCam != null)
-		{
-			var clonedCamID = g_pCameraManager.CloneCamera(pCam.m_id);	
-			pClonedCam = g_pCameraManager.GetCamera(clonedCamID);
-		}
+		this.backupWorld = WebGL_GetMatrix(MATRIX_WORLD);
+		this.backupView = WebGL_GetMatrix(MATRIX_VIEW);
+		this.backupProj = WebGL_GetMatrix(MATRIX_PROJECTION);
 
 		// Draw everything on this layer to the temporary surface
 		surface_set_target(this.tempSurfaceID);
 		draw_clear_alpha(0, 0.0);
 
-		if (pClonedCam != null)
-		{			
-			UpdateCamera(pClonedCam.GetViewX(), pClonedCam.GetViewY(), pClonedCam.GetViewWidth(), pClonedCam.GetViewHeight(), pClonedCam.GetViewAngle(), g_pCameraManager.GetActiveCamera());
-
-			g_pCameraManager.DestroyCamera(pClonedCam.m_id);
-		}
+		WebGL_SetMatrix(MATRIX_WORLD, this.backupWorld);
+		WebGL_SetMatrix(MATRIX_VIEW, this.backupView);
+		WebGL_SetMatrix(MATRIX_PROJECTION, this.backupProj);
 
 		g_webGL.RSMan.SaveStates();
 
@@ -423,6 +416,10 @@ yyFilterHost.prototype.LayerEnd = function (_layerID)
 	{
 		g_webGL.RSMan.RestoreStates(true);
 		surface_reset_target();
+
+		WebGL_SetMatrix(MATRIX_WORLD, this.backupWorld);
+		WebGL_SetMatrix(MATRIX_VIEW, this.backupView);
+		WebGL_SetMatrix(MATRIX_PROJECTION, this.backupProj);
 	}
 	else
 	{

--- a/scripts/yyEffects.js
+++ b/scripts/yyEffects.js
@@ -373,8 +373,10 @@ yyFilterHost.prototype.LayerBegin = function (_layerID)
 		draw_clear_alpha(0, 0.0);
 
 		WebGL_SetMatrix(MATRIX_WORLD, this.backupWorld);
-		WebGL_SetMatrix(MATRIX_VIEW, this.backupView);
-		WebGL_SetMatrix(MATRIX_PROJECTION, this.backupProj);
+		var tempCam = g_pCameraManager.GetTempCamera();
+		tempCam.SetViewMat(this.backupView);
+		tempCam.SetProjMat(this.backupProj);
+		tempCam.ApplyMatrices();
 
 		g_webGL.RSMan.SaveStates();
 
@@ -418,8 +420,10 @@ yyFilterHost.prototype.LayerEnd = function (_layerID)
 		surface_reset_target();
 
 		WebGL_SetMatrix(MATRIX_WORLD, this.backupWorld);
-		WebGL_SetMatrix(MATRIX_VIEW, this.backupView);
-		WebGL_SetMatrix(MATRIX_PROJECTION, this.backupProj);
+		var tempCam = g_pCameraManager.GetTempCamera();
+		tempCam.SetViewMat(this.backupView);
+		tempCam.SetProjMat(this.backupProj);
+		tempCam.ApplyMatrices();
 	}
 	else
 	{

--- a/scripts/yyRoom.js
+++ b/scripts/yyRoom.js
@@ -1337,11 +1337,24 @@ function UpdateCamera(_x, _y, _w, _h, _angle, pCam)
 	}
 }
 
+function UpdateTempCamera(_x, _y, _w, _h, _angle)
+{
+	var tempCam = g_pCameraManager.GetTempCamera();
+	UpdateCamera(_x, _y, _w, _h, _angle, tempCam);
+	g_pCameraManager.SetActiveCamera(tempCam.GetID());		
+}
+
 function UpdateDefaultCamera(_x, _y, _w, _h, _angle)
 {
 	var defaultcam = g_pCameraManager.GetCamera(g_DefaultCameraID);
-	UpdateCamera(_x, _y, _w, _h, _angle, defaultcam);
-	g_pCameraManager.SetActiveCamera(g_DefaultCameraID);		
+	if (defaultcam == null)
+	{
+		UpdateTempCamera(_x, _y, _w, _h, _angle);
+	}
+	else
+	{
+		g_pCameraManager.SetActiveCamera(g_DefaultCameraID);
+	}
 }
 
 function DrawTile(_rect,_back,_indexdata,_frame,_x,_y,_depth)
@@ -3589,7 +3602,7 @@ yyRoom.prototype.DrawViews = function (r) {
 
 	if (g_isZeus)
 	{
-		UpdateDefaultCamera(0, 0, r.right,r.bottom,0);
+		UpdateTempCamera(0, 0, r.right,r.bottom,0);
 	}
 	
 	g_DisplayScaleX = 1;
@@ -3607,6 +3620,7 @@ yyRoom.prototype.DrawViews = function (r) {
 		Graphics_SetViewPort(0, 0, g_ApplicationWidth, g_ApplicationHeight);
          
 		if (g_isZeus) {
+			g_DefaultView.cameraID = g_DefaultCameraID;
 		    UpdateDefaultCamera(0, 0, g_RunRoom.m_width, g_RunRoom.m_height, 0);
 		}
 		else {


### PR DESCRIPTION
Fixed an issue where user's custom view & projection matrices were not kept when effect layers were used. This now works with:

* `camera_set_default(camera)`
* `view_camera[i] = camera`
* `camera_apply(camera)`
* `matrix_set(matrix_view/projection, matrix)`

Issue link: https://bugs.opera.com/browse/GM-5979
