### PR TITLE
GM-7765: Fixed tile culling not working properly when matrix_set is used

### DIFF
--- a/scripts/CameraManager.js
+++ b/scripts/CameraManager.js
@@ -512,7 +512,9 @@ CCamera.prototype.GetCamRight = function () {
 
 
 
-CCamera.prototype.ApplyMatrices = function () {
+CCamera.prototype.ApplyMatrices = function (_flipProj) {
+    if (_flipProj === undefined) _flipProj = true;
+    
     if (this.IsOrthoProj()) {
         var campos = this.GetCamPos();
 
@@ -586,7 +588,7 @@ CCamera.prototype.ApplyMatrices = function () {
         graphics._setTransform(g_transform[0], g_transform[3], g_transform[1], g_transform[4], g_transform[2], g_transform[5]);
     }
 
-    if (g_RenderTargetActive == -1) {
+    if (!_flipProj || g_RenderTargetActive == -1) {
         WebGL_SetMatrix(MATRIX_PROJECTION, this.m_projMat);
     }
     else {

--- a/scripts/functions/Function_D3D.js
+++ b/scripts/functions/Function_D3D.js
@@ -1656,7 +1656,55 @@ function WebGL_Matrix_Set(_type, _matrix) {
         m.m[i] = _matrix[i];
     }
     WebGL_SetMatrix(_type, m);*/
-    WebGL_SetMatrix(_type, _matrix);
+
+    switch (_type)
+    {
+        case MATRIX_WORLD:
+        {
+            WebGL_SetMatrix(_type, _matrix);
+        }
+        break;
+        
+        case MATRIX_VIEW:
+        {
+            var matView = new Matrix(_matrix);
+            var matProj = new Matrix();
+            var matTemp = WebGL_GetMatrix(MATRIX_PROJECTION);
+            
+            if (g_RenderTargetActive == -1)
+            {
+                matProj = matTemp;
+            }
+            else
+            {
+                var flipMat = new Matrix();
+                flipMat.unit();
+                flipMat.m[_22] = -1;
+
+                matProj.Multiply(matTemp, flipMat);
+            }
+
+            var tempCam = g_pCameraManager.GetTempCamera();
+            tempCam.SetViewMat(matView);
+            tempCam.SetProjMat(matProj);
+            tempCam.ApplyMatrices();
+        }
+        break;
+        
+        case MATRIX_PROJECTION:
+        {
+            var matView = WebGL_GetMatrix(MATRIX_VIEW);
+            var matProj = new Matrix(_matrix);
+            var tempCam = g_pCameraManager.GetTempCamera();
+            tempCam.SetViewMat(matView);
+            tempCam.SetProjMat(matProj);
+            tempCam.ApplyMatrices();
+        }
+        break;
+        
+        default:
+            break;
+    }
 }
 
 function WebGL_matrix_build_identity() {

--- a/scripts/functions/Function_D3D.js
+++ b/scripts/functions/Function_D3D.js
@@ -1668,26 +1668,11 @@ function WebGL_Matrix_Set(_type, _matrix) {
         case MATRIX_VIEW:
         {
             var matView = new Matrix(_matrix);
-            var matProj = new Matrix();
-            var matTemp = WebGL_GetMatrix(MATRIX_PROJECTION);
-            
-            if (g_RenderTargetActive == -1)
-            {
-                matProj = matTemp;
-            }
-            else
-            {
-                var flipMat = new Matrix();
-                flipMat.unit();
-                flipMat.m[_22] = -1;
-
-                matProj.Multiply(matTemp, flipMat);
-            }
-
+            var matProj = WebGL_GetMatrix(MATRIX_PROJECTION);
             var tempCam = g_pCameraManager.GetTempCamera();
             tempCam.SetViewMat(matView);
             tempCam.SetProjMat(matProj);
-            tempCam.ApplyMatrices();
+            tempCam.ApplyMatrices(false);
         }
         break;
         
@@ -1698,7 +1683,7 @@ function WebGL_Matrix_Set(_type, _matrix) {
             var tempCam = g_pCameraManager.GetTempCamera();
             tempCam.SetViewMat(matView);
             tempCam.SetProjMat(matProj);
-            tempCam.ApplyMatrices();
+            tempCam.ApplyMatrices(false);
         }
         break;
         

--- a/scripts/yyEffects.js
+++ b/scripts/yyEffects.js
@@ -366,19 +366,7 @@ yyFilterHost.prototype.LayerBegin = function (_layerID)
 
 		this.backupWorld = WebGL_GetMatrix(MATRIX_WORLD);
 		this.backupView = WebGL_GetMatrix(MATRIX_VIEW);
-		var matProj = WebGL_GetMatrix(MATRIX_PROJECTION);
-
-		if (g_RenderTargetActive == -1)
-		{
-			this.backupProj = matProj;
-		}
-		else
-		{
-			var flipMat = new Matrix();
-			flipMat.unit();
-			flipMat.m[_22] = -1.0;
-			this.backupProj.Multiply(matProj, flipMat);
-		}
+		this.backupProj = WebGL_GetMatrix(MATRIX_PROJECTION);
 
 		// Draw everything on this layer to the temporary surface
 		surface_set_target(this.tempSurfaceID);
@@ -388,7 +376,7 @@ yyFilterHost.prototype.LayerBegin = function (_layerID)
 		var tempCam = g_pCameraManager.GetTempCamera();
 		tempCam.SetViewMat(this.backupView);
 		tempCam.SetProjMat(this.backupProj);
-		tempCam.ApplyMatrices();
+		tempCam.ApplyMatrices(false);
 
 		g_webGL.RSMan.SaveStates();
 
@@ -435,7 +423,7 @@ yyFilterHost.prototype.LayerEnd = function (_layerID)
 		var tempCam = g_pCameraManager.GetTempCamera();
 		tempCam.SetViewMat(this.backupView);
 		tempCam.SetProjMat(this.backupProj);
-		tempCam.ApplyMatrices();
+		tempCam.ApplyMatrices(false);
 	}
 	else
 	{


### PR DESCRIPTION
Changing `matrix_set` functions to use the camera class, which properly updates view extents, which are required for proper tile culling. Tile culling was already working properly with `camera_apply` in HTML5 and it's a C++ issue only.

Issue link: https://bugs.opera.com/browse/GM-7765
