### PR TITLE
GM-7783: Time source return values

### DIFF
--- a/scripts/functions/Function_Time.js
+++ b/scripts/functions/Function_Time.js
@@ -527,7 +527,7 @@ function TimeSource_GetChildren(_id)
 
 	if (ts != null)
 	{
-		return ts.GetChildren();
+		return ts.GetChildren().map(_child => _child.GetId());
 	}
 
 	NonExistentError(_id);

--- a/scripts/functions/Function_Time.js
+++ b/scripts/functions/Function_Time.js
@@ -362,7 +362,7 @@ function TimeSource_GetPeriod(_id)
 		NonExistentError(_id);
 	}
 
-	return null;
+	return undefined;
 }
 
 function time_source_get_reps_completed(_id)
@@ -387,7 +387,7 @@ function TimeSource_GetRepsCompleted(_id)
 		NonExistentError(_id);
 	}
 
-	return null;
+	return undefined;
 }
 
 function time_source_get_reps_remaining(_id)
@@ -412,7 +412,7 @@ function TimeSource_GetRepsRemaining(_id)
 		NonExistentError(_id);
 	}
 
-	return null;
+	return undefined;
 }
 
 function time_source_get_units(_id)
@@ -437,7 +437,7 @@ function TimeSource_GetUnits(_id)
 		NonExistentError(_id);
 	}
 
-	return null;
+	return undefined;
 }
 
 function time_source_get_time_remaining(_id)
@@ -462,7 +462,7 @@ function TimeSource_GetTimeRemaining(_id)
 		NonExistentError(_id);
 	}
 
-	return null;
+	return undefined;
 }
 
 function time_source_get_state(_id)
@@ -487,7 +487,7 @@ function TimeSource_GetState(_id)
 		NonExistentError(_id);
 	}
 
-	return null;
+	return undefined;
 }
 
 function time_source_get_parent(_id)
@@ -512,7 +512,7 @@ function TimeSource_GetParent(_id)
 		NonExistentError(_id);
 	}
 
-	return null;
+	return undefined;
 }
 
 function time_source_get_children(_id)
@@ -532,7 +532,7 @@ function TimeSource_GetChildren(_id)
 
 	NonExistentError(_id);
 
-	return null;
+	return undefined;
 }
 
 function time_source_exists(_id)


### PR DESCRIPTION
Fixed two bugs here:
- `time_source_get_children` now returns an array of time source IDs rather than an array of the time source objects themselves.
- Top-level time source functions now return `undefined` on failure rather than `null`.