### PR TITLE
GM-7765: Tile culling not working properly when function matrix_set is used

### DIFF
--- a/scripts/CameraManager.js
+++ b/scripts/CameraManager.js
@@ -513,56 +513,7 @@ CCamera.prototype.GetCamRight = function () {
 
 
 CCamera.prototype.ApplyMatrices = function () {
-    if (this.IsOrthoProj()) {
-        var campos = this.GetCamPos();
-
-        // Experimental
-        // Back transform clip space extents by the inverse of our view-proj matrix to get our room-space bounds
-        var leftvec, rightvec, upvec, downvec;
-        leftvec = this.m_invViewProjMat.TransformVec3(new Vector3(-1.0, 0.0, 0.0));
-        rightvec = this.m_invViewProjMat.TransformVec3(new Vector3(1.0, 0.0, 0.0));
-        upvec = this.m_invViewProjMat.TransformVec3(new Vector3(0.0, 1.0, 0.0));
-        downvec = this.m_invViewProjMat.TransformVec3(new Vector3(0.0, -1.0, 0.0));
-
-        var diffh = rightvec.Sub(leftvec);
-        var diffv = upvec.Sub(downvec);
-
-        g_worldw = diffh.Length();
-        g_worldh = diffv.Length();
-
-        g_worldx = campos.X - (g_worldw * 0.5);
-        g_worldy = campos.Y - (g_worldh * 0.5);
-
-        var normdiffv = diffv;
-        normdiffv.Normalise();
-
-        var angle = Math.acos(normdiffv.Y);
-        if (normdiffv.X < 0.0) {
-            angle = (2.0 * Math.PI) - angle;
-        }
-
-        var ViewAreaA = (angle / (2.0 * Math.PI)) * 360.0;
-
-        /*g_worldx = campos.X - (this.m_viewWidth * 0.5);
-		g_worldy = campos.Y - (this.m_viewHeight * 0.5);
-		g_worldw = this.m_viewWidth;
-		g_worldh = this.m_viewHeight;
-		var ViewAreaA = this.m_viewAngle;*/
-
-        //Needs implmenting
-        SetViewExtents(g_worldx, g_worldy, g_worldw, g_worldh, ViewAreaA);
-
-
-    }
-    else {
-        // Not ideal, but set the view area to the room extents if this is a perspective camera
-        // We would need to change the way we do culling and work out extents for tile drawing etc across the codebase to handle this properly
-        g_worldx = 0;
-        g_worldy = 0;
-        g_worldw = g_RunRoom != null ? g_RunRoom.GetWidth() : 1;
-        g_worldh = g_RunRoom != null ? g_RunRoom.GetHeight() : 1;
-        SetViewExtents(g_worldx, g_worldy, g_worldw, g_worldh, 0);
-    }
+    UpdateViewExtents(this.m_viewMat, this.m_projMat, this.m_invViewMat, this.m_invViewProjMat);
 
     if (g_webGL != null) {
         WebGL_SetMatrix(MATRIX_VIEW, this.m_viewMat);

--- a/scripts/functions/Function_D3D.js
+++ b/scripts/functions/Function_D3D.js
@@ -1657,6 +1657,31 @@ function WebGL_Matrix_Set(_type, _matrix) {
     }
     WebGL_SetMatrix(_type, m);*/
     WebGL_SetMatrix(_type, _matrix);
+
+    if (_type == MATRIX_VIEW)
+    {
+        var matProj = new Matrix();
+        var matTemp = WebGL_GetMatrix(MATRIX_PROJECTION);
+
+        if (g_RenderTargetActive == -1)
+        {
+            matProj = matTemp;
+        }
+        else
+        {
+            var flipMat = new Matrix();
+            flipMat.unit();
+            flipMat.m[_22] = -1;
+
+            matProj.Multiply(matTemp, flipMat);
+        }
+        
+        UpdateViewExtents(new Matrix(_matrix), matProj);
+    }
+    else if (_type == MATRIX_PROJECTION)
+    { 
+        UpdateViewExtents(WebGL_GetMatrix(MATRIX_VIEW), new Matrix(_matrix));
+    }
 }
 
 function WebGL_matrix_build_identity() {

--- a/scripts/functions/Function_Graphics.js
+++ b/scripts/functions/Function_Graphics.js
@@ -2719,6 +2719,83 @@ function SetViewExtents(xview, yview, wview, hview,  angle)
 	}
 };
 
+// Updates view extents from view and projection matrices. Optionally inverse
+// view and inverse view-projection matrices can be provided to speed up
+// computations if they are already available.
+function UpdateViewExtents(_matView, _matProj, _matInvView, _matInvViewProj)
+{
+    var isOrthoProj = (_matProj.m[11] == 0);
+    
+    if (isOrthoProj)
+    {
+        if (_matInvView === undefined)
+        {
+            _matInvView = new Matrix();
+            _matInvView.Invert(_matView);
+        }
+        
+        if (_matInvViewProj === undefined)
+        {
+            var matViewProj = new Matrix();
+            matViewProj.Multiply(_matView, _matProj);
+            
+            _matInvViewProj = new Matrix();
+            _matInvViewProj.Invert(matViewProj);
+        }
+        
+        var campos = new Vector3();
+        campos.X = _matInvView.m[_41];
+        campos.Y = _matInvView.m[_42];
+        campos.Z = _matInvView.m[_43];
+
+        // Experimental
+        // Back transform clip space extents by the inverse of our view-proj matrix to get our room-space bounds
+        var leftvec, rightvec, upvec, downvec;
+        leftvec = _matInvViewProj.TransformVec3(new Vector3(-1.0, 0.0, 0.0));
+        rightvec = _matInvViewProj.TransformVec3(new Vector3(1.0, 0.0, 0.0));
+        upvec = _matInvViewProj.TransformVec3(new Vector3(0.0, 1.0, 0.0));
+        downvec = _matInvViewProj.TransformVec3(new Vector3(0.0, -1.0, 0.0));
+
+        var diffh = rightvec.Sub(leftvec);
+        var diffv = upvec.Sub(downvec);
+
+        g_worldw = diffh.Length();
+        g_worldh = diffv.Length();
+
+        g_worldx = campos.X - (g_worldw * 0.5);
+        g_worldy = campos.Y - (g_worldh * 0.5);
+
+        var normdiffv = diffv;
+        normdiffv.Normalise();
+
+        var angle = Math.acos(normdiffv.Y);
+        if (normdiffv.X < 0.0) {
+            angle = (2.0 * Math.PI) - angle;
+        }
+
+        var ViewAreaA = (angle / (2.0 * Math.PI)) * 360.0;
+
+        /*g_worldx = campos.X - (this.m_viewWidth * 0.5);
+		g_worldy = campos.Y - (this.m_viewHeight * 0.5);
+		g_worldw = this.m_viewWidth;
+		g_worldh = this.m_viewHeight;
+		var ViewAreaA = this.m_viewAngle;*/
+
+        //Needs implmenting
+        SetViewExtents(g_worldx, g_worldy, g_worldw, g_worldh, ViewAreaA);
+    }
+    else
+    {
+        // Not ideal, but set the view area to the room extents if this is a perspective camera
+        // We would need to change the way we do culling and work out extents for tile drawing etc across the codebase to handle this properly
+        g_worldx = 0;
+        g_worldy = 0;
+        g_worldw = g_RunRoom != null ? g_RunRoom.GetWidth() : 1;
+        g_worldh = g_RunRoom != null ? g_RunRoom.GetHeight() : 1;
+        SetViewExtents(g_worldx, g_worldy, g_worldw, g_worldh, 0);
+    }
+}
+
 function GetViewFrustum()
 {
     if (g_ViewFrustumDirty)


### PR DESCRIPTION
Pulled out code from camera's `ApplyMatrices` method into a new function `UpdateViewExtents` and calling it from `matrix_set` when changing the view or the projection matrix. Using `camera_apply` already works in the HTML5 runner and is only a C++ runner issue.

Issue link: https://bugs.opera.com/browse/GM-7765
