### PR TITLE
Checking for the source of an unhandled error

### DIFF
--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -169,8 +169,6 @@ function yyUnhandledRejectionHandler( error )
 {
 	var string =  "Unhandled Rejection - " + error.message;
 	console.error(string);
-	//print( string );
-	//alert( string );
 	if (error && error.promise) {
 		error.promise.catch(function(err){
 			var _endGame = true;
@@ -178,14 +176,17 @@ function yyUnhandledRejectionHandler( error )
 				var _urlPos = err.stack.indexOf("https://");
 				if (_urlPos < 0) _urlPos = err.stack.indexOf("http://");
 				if (_urlPos >= 0) {
-					var _url = err.stack.slice(_urlPos);
-					_urlPos = _url.indexOf(":", _urlPos + 7);
-					if (_urlPos > 0) {
-						var _errUrl = new URL(_url.slice(0, _urlPos));
-						if ((_errUrl.hostname != window.location.hostname) ||
-							(_errUrl.pathname.indexOf(g_pGMFile.Options.GameDir) !== 1)){
-							// The error is caused by an external resource.
-							_endGame = false;
+					var _rows = err.stack.slice(_urlPos).split(/\r\n|\r|\n/g);
+					if (_rows.length > 0) {
+						var _url = _rows[0];
+						_urlPos = _url.lastIndexOf("/");
+						if (_urlPos > 0) {
+							var _errUrl = new URL(_url.slice(0, _urlPos + 1));
+							if ((_errUrl.hostname != window.location.hostname) ||
+								(_errUrl.pathname.indexOf(g_pGMFile.Options.GameDir) < 0)){
+								// The error is caused by an external resource.
+								_endGame = false;
+							}
 						}
 					}
 				}
@@ -197,7 +198,7 @@ function yyUnhandledRejectionHandler( error )
 				game_end(-2);
 				debugger;
 			}
-        	});
+		});
 	}
 	return false;
 }

--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -168,11 +168,14 @@ function yyUnhandledExceptionHandler( event )
 function yyUnhandledRejectionHandler( error )
 {
 	var string =  "Unhandled Rejection - " + error.message;
+    console.error(string);
+    return false;
+    /*
 	print( string );
 	//alert( string );
 	game_end(-2);
 	debugger;
-	return false;
+	return false;*/
 }
 
 window.addEventListener( "error", yyUnhandledExceptionHandler );

--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -169,6 +169,36 @@ function yyUnhandledRejectionHandler( error )
 {
 	var string =  "Unhandled Rejection - " + error.message;
 	console.error(string);
+	//print( string );
+	//alert( string );
+	if (error && error.promise) {
+		error.promise.catch(function(err){
+			var _endGame = true;
+			try {
+				var _urlPos = err.stack.indexOf("https://");
+				if (_urlPos < 0) _urlPos = err.stack.indexOf("http://");
+				if (_urlPos >= 0) {
+					var _url = err.stack.slice(_urlPos);
+					_urlPos = _url.indexOf(":", _urlPos + 7);
+					if (_urlPos > 0) {
+						var _errUrl = new URL(_url.slice(0, _urlPos));
+						if ((_errUrl.hostname != window.location.hostname) ||
+							(_errUrl.pathname.indexOf(g_pGMFile.Options.GameDir) !== 1)){
+							// The error is caused by an external resource.
+							_endGame = false;
+						}
+					}
+				}
+			}
+			catch (e) {
+				console.error(e.message);
+			}
+			if (_endGame) {
+				game_end(-2);
+				debugger;
+			}
+        	});
+	}
 	return false;
 }
 

--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -168,14 +168,8 @@ function yyUnhandledExceptionHandler( event )
 function yyUnhandledRejectionHandler( error )
 {
 	var string =  "Unhandled Rejection - " + error.message;
-    console.error(string);
-    return false;
-    /*
-	print( string );
-	//alert( string );
-	game_end(-2);
-	debugger;
-	return false;*/
+	console.error(string);
+	return false;
 }
 
 window.addEventListener( "error", yyUnhandledExceptionHandler );


### PR DESCRIPTION
If the error appears in an external file, the game will continue to work.
An unhandled exception returns a promise that we can handle. The error contains a stack with the URL of the file where the error occurred. I check that the file has a different hostname or is located outside the game folder.

Close [Game Maker-HTML5/issues/173](https://github.com/YoYoGames/GameMaker-HTML5/issues/173)