### PR TITLE
GM-2706: Added function part_type_subimage

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -429,6 +429,21 @@ var part_type_sprite = ParticleType_Sprite;
 
 // #############################################################################################
 /// Function:<summary>
+///          	This function can be used to set a particle type to use a custom sub-image
+///             (frame) of a sprite. If the particle's sprite is animated, then this sub-image
+///             will be used as the starting frame of the animation.
+///          </summary>
+///
+/// In:		<param name="_ind"></param>
+///			<param name="_subimg"></param>
+/// Out:	<returns>
+///				
+///			</returns>
+// #############################################################################################
+var part_type_subimage = ParticleType_Subimage;
+
+// #############################################################################################
+/// Function:<summary>
 ///          	Sets the size parameters for the particle type. You specify the minimum starting 
 ///             size, the maximum starting size, the size increase in each step (use a negative 
 ///             number for a decrease in size) and the amount of wiggling. 

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -808,6 +808,25 @@ function ParticleType_Sprite(_ind, _sprite, _anim, _stretch, _rand)
 
 // #############################################################################################
 /// Function:<summary>
+///          	Sets the starting sprite sub-image for the indicated particle type
+///          </summary>
+///
+/// In:		<param name="_ind">Particle type ti change</param>
+///			<param name="_subimg"></param>
+/// Out:	<returns>
+///				
+///			</returns>
+// #############################################################################################
+function ParticleType_Subimage(_ind, _subimg)
+{
+    var pPar = g_ParticleTypes[yyGetInt32(_ind)];
+	if( pPar == null || pPar==undefined ) return;
+
+	pPar.spritestart = yyGetInt32(_subimg);
+}
+
+// #############################################################################################
+/// Function:<summary>
 ///				Sets the size for the indicated particle type
 ///          </summary>
 ///


### PR DESCRIPTION
Added new function `part_type_subimage` using which you can configure particle's sprite subimage.

Issue link: https://bugs.opera.com/browse/GM-2706
