### PR TITLE
GM-7857: Added new function part_emitter_enable

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -54,6 +54,7 @@ function particle_get_info(_ind)
             variable_struct_set(pEmitterI, "ymax", templateEmitter.ymax);
             variable_struct_set(pEmitterI, "distribution", templateEmitter.posdistr);
             variable_struct_set(pEmitterI, "shape", templateEmitter.shape);
+            variable_struct_set(pEmitterI, "enabled", templateEmitter.enabled);
 
             var pPartTypeI = new GMLObject();
             var particleType = g_ParticleTypes[templateEmitter.parttype];
@@ -807,6 +808,21 @@ var part_emitter_destroy  = ParticleSystem_Emitter_Destroy;
 ///			</returns>
 // #############################################################################################
 var part_emitter_destroy_all = ParticleSystem_Emitter_DestroyAll;
+
+// #############################################################################################
+/// Function:<summary>
+///          	Enables or disables a particle emitter. Disabled emitters aren't updated nor
+///             rendered and they don't spawn new particles.
+///          </summary>
+///
+/// In:		<param name="_ps"></param>
+///			<param name="_ind"></param>
+///			<param name="_enable"></param>
+/// Out:	<returns>
+///				
+///			</returns>
+// #############################################################################################
+var part_emitter_enable = ParticleSystem_Emitter_Enable;
 
 // #############################################################################################
 /// Function:<summary>

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -1448,6 +1448,27 @@ function ParticleSystem_Emitter_DestroyAll(_ps)
 	return true;
 }
 
+// #############################################################################################
+/// Function:<summary>
+///				Enables or disables a particle emitter
+///          </summary>
+///
+/// In:		<param name="_ps"></param>
+///			<param name="_ind"></param>
+///			<param name="_enable"></param>
+/// Out:	<returns>
+///			</returns>
+// #############################################################################################
+function	ParticleSystem_Emitter_Enable(_ps, _ind, _enable)
+{
+	_ps = yyGetInt32(_ps);
+	_ind = yyGetInt32(_ind);
+
+	if (!ParticleSystem_Exists(_ps)) return;
+	if (!ParticleSystem_Emitter_Exists(_ps, _ind)) return;
+
+	g_ParticleSystems[_ps].emitters[_ind].enabled = yyGetBool(_enable);
+}
 
 // #############################################################################################
 /// Function:<summary>


### PR DESCRIPTION
Added new function `part_emitter_enable`, which enables or disables a particle emitter. Disabled particle emitters aren't updated nor rendered and they don't spawn new particles until they're enabled again. Additionally the function `particle_get_info` returns this `enabled` state of particle emitters.

Issue link: https://bugs.opera.com/browse/GM-7857
