### PR TITLE
[GM-7868] Filter and Effect fx_get|set_single_layer bug

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -4988,12 +4988,7 @@ function fx_get_single_layer(_effect)
 		return -1;
     }
 
-    var varId = "gml" + EFFECT_AFFECT_SINGLE_LAYER_VAR;
-	if ((typeof g_var2obf !== "undefined") && (g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR] != undefined)) {
-		varId = g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR];
-	}
-
-    return _effect.instance.pEffectObj[varId];
+    return _effect.instance.GetParamVar(EFFECT_AFFECT_SINGLE_LAYER_VAR) == 1 ? true : false;
 }
 
 function fx_set_parameter(_effect, _name, _val)
@@ -5063,12 +5058,7 @@ function fx_set_single_layer(_effect, _val)
 		return -1;
     }
 
-    var varId = "gml" + EFFECT_AFFECT_SINGLE_LAYER_VAR;
-	if ((typeof g_var2obf !== "undefined") && (g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR] != undefined)) {
-		varId = g_var2obf[EFFECT_AFFECT_SINGLE_LAYER_VAR];
-	}
-
-    _effect.instance.pEffectObj[varId] = _val;
+    _effect.instance.SetParam(EFFECT_AFFECT_SINGLE_LAYER_VAR, FAE_PARAM_BOOL, 1, [ yyGetBool(_val) ]);
 }
 
 function layer_set_fx(_layerId, _effect)


### PR DESCRIPTION
The function fx_get_single_layer and fx_set_single_layer are reading and writing to the wrong place in case of Filters. Filters work different from effects in a sense that they parameters names are kept as is (they are simply shaders)... "effects" on the other end are executed inside GML code so their parameters need to be prefixed with the "gml" so they correctly work within GML