### PR TITLE
GM-7245: Added function part_particles_burst(ind,x,y,partsys) for bursting particle system asset

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -348,6 +348,21 @@ var part_particles_create_colour = ParticleSystem_Particles_Create_Color;
 
 // #############################################################################################
 /// Function:<summary>
+///          	
+///          </summary>
+///
+/// In:		<param name="_ind"></param>
+///			<param name="_x"></param>
+///			<param name="_y"></param>
+///			<param name="_partsys"></param>
+/// Out:	<returns>
+///				
+///			</returns>
+// #############################################################################################
+var part_particles_burst = ParticleSystem_Particles_Burst;
+
+// #############################################################################################
+/// Function:<summary>
 ///          	This functions removes all particles in the system.
 ///          </summary>
 ///

--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -348,7 +348,10 @@ var part_particles_create_colour = ParticleSystem_Particles_Create_Color;
 
 // #############################################################################################
 /// Function:<summary>
-///          	
+///          	This function allows you to burst all particles defined in a particle system
+///          	resource at any position in the room. The final area, distribution and number
+///          	of the particles created depends on the configuration of emitters inside of the
+///          	particle system resource.
 ///          </summary>
 ///
 /// In:		<param name="_ind"></param>

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -1784,7 +1784,10 @@ function	ParticleSystem_Particles_Create_Color( _ps, _x, _y, _parttype, _col, _n
 
 // #############################################################################################
 /// Function:<summary>
-///          	
+///          	This function allows you to burst all particles defined in a particle system
+///          	resource at any position in the room. The final area, distribution and number
+///          	of the particles created depends on the configuration of emitters inside of the
+///          	particle system resource.
 ///          </summary>
 ///
 /// In:		<param name="_ind"></param>

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -1813,23 +1813,19 @@ function ParticleSystem_Particles_Burst(_ps, _x, _y, _partsys)
 	} // end if
 
 	var system = g_ParticleSystems[_ps];
-
 	var emitterCount = asset.emitters.length;
 
-	for (var i = 0; i < emitterCount - system.emitters.length; ++i)
-	{
+	for (var i = emitterCount - system.emitters.length; i > 0; --i)
 		ParticleSystem_Emitter_Create(_ps);
-	}
 
 	for (var i = 0; i < emitterCount; ++i)
 	{
-		var ind = emitterCount - i - 1;
-		var emitterIndex = asset.emitters[i];
+		var emitterIndex = asset.emitters[emitterCount - i - 1];
 		var emitter = g_PSEmitters[emitterIndex];
 		var emitterWidth = emitter.xmax - emitter.xmin;
 		var emitterHeight = emitter.ymax - emitter.ymin;
 
-		ParticleSystem_Emitter_Burst_Impl(system, system.emitters[ind], _x + emitter.xmin, _y + emitter.ymin,
+		ParticleSystem_Emitter_Burst_Impl(system, system.emitters[i], _x + emitter.xmin, _y + emitter.ymin,
 			emitterWidth, emitterHeight, emitter.shape, emitter.posdistr, emitter.parttype, emitter.number);
 	}
 }


### PR DESCRIPTION
Adding new function `part_particles_burst(ind,x,y,partsys)`, using which you can burst all particles defined in a particle system resource anywhere in the room. The final area, distribution and number of the particles created depends on the configuration of emitters inside of the particle system resource.

Issue link: https://bugs.opera.com/browse/GM-7245
