### PR TITLE
GM-5939: Mouse lock API

### DIFF
--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -2326,8 +2326,8 @@ function GameMaker_Tick()
 		    if (ErrorCount <= 0) break;
 		}
 
-
-
+        g_MouseDeltaX = 0;
+        g_MouseDeltaY = 0;
     }
     
 	// if in DEBUG mode, do debug "stuff"

--- a/scripts/functions/Function_Window.js
+++ b/scripts/functions/Function_Window.js
@@ -716,7 +716,53 @@ function window_mouse_set(x,y)
     ErrorFunction("window_mouse_set()");
 }
 
+// #############################################################################################
+/// Function:<summary>
+///             Hides the mouse cursor and locks it in place
+///          </summary>
+///
+/// In:		 <param name="_enable"></param>
+/// Out:	 <returns>
+///				
+///			 </returns>
+// #############################################################################################
+function window_mouse_set_locked(_enable)
+{
+}
 
+// #############################################################################################
+/// Function:<summary>
+///             Checks whether the mouse is locked in place
+///          </summary>
+///
+/// Out:	 <returns>
+///				True if the mouse is locked in place
+///			 </returns>
+// #############################################################################################
+function window_mouse_get_locked()
+{
+	return false;
+}
+
+// #############################################################################################
+/// Out:	 <returns>
+///				Returns how many pixels has the mouse moved on the x axis since the last frame
+///			 </returns>
+// #############################################################################################
+function window_mouse_get_delta_x()
+{
+	return 0;
+}
+
+// #############################################################################################
+/// Out:	 <returns>
+///				Returns how many pixels has the mouse moved on the y axis since the last frame
+///			 </returns>
+// #############################################################################################
+function window_mouse_get_delta_y()
+{
+	return 0;
+}
 
 // #############################################################################################
 /// Function:<summary>

--- a/scripts/functions/Function_Window.js
+++ b/scripts/functions/Function_Window.js
@@ -728,6 +728,30 @@ function window_mouse_set(x,y)
 // #############################################################################################
 function window_mouse_set_locked(_enable)
 {
+    if (_enable)
+    {
+        var _requestPointerLock = canvas.requestPointerLock
+            || canvas.mozRequestPointerLock
+            || canvas.webkitRequestPointerLock
+            || canvas.msRequestPointerLock;
+        
+        if (!_requestPointerLock) return;
+        
+        var res = _requestPointerLock.call(canvas);
+        if (res && res.then) res.catch(function () {});
+    }
+    else
+    {
+        var _exitPointerLock = document.exitPointerLock
+            || document.mozExitPointerLock
+            || document.webkitExitPointerLock
+            || document.msExitPointerLock;
+        
+        if (!_exitPointerLock) return;
+        
+        var res = _exitPointerLock.call(document);
+        if (res && res.then) res.catch(function () {});
+    }
 }
 
 // #############################################################################################
@@ -741,7 +765,7 @@ function window_mouse_set_locked(_enable)
 // #############################################################################################
 function window_mouse_get_locked()
 {
-	return false;
+	return g_MouseLocked;
 }
 
 // #############################################################################################
@@ -751,7 +775,7 @@ function window_mouse_get_locked()
 // #############################################################################################
 function window_mouse_get_delta_x()
 {
-	return 0;
+	return g_MouseDeltaX;
 }
 
 // #############################################################################################
@@ -761,7 +785,7 @@ function window_mouse_get_delta_x()
 // #############################################################################################
 function window_mouse_get_delta_y()
 {
-	return 0;
+	return g_MouseDeltaY;
 }
 
 // #############################################################################################

--- a/scripts/yyIOManager.js
+++ b/scripts/yyIOManager.js
@@ -42,7 +42,10 @@ var g_ButtonButton = 0,
 	g_MouseUP = 0,
 	g_MouseDOWN = 0,
 	g_BrowserInputCapture = false,
-	g_MouseWheel = 0;
+	g_MouseWheel = 0,
+	g_MouseLocked = false,
+	g_MouseDeltaX = 0,
+	g_MouseDeltaY = 0;
 
 
 var g_KeyDown = [];
@@ -885,6 +888,18 @@ function onMouseMove(_evt) {
 
 	g_EventMouseX = _evt.clientX;
 	g_EventMouseY = _evt.clientY;
+	
+	g_MouseDeltaX = _evt.movementX
+		|| _evt.mozMovementX
+		|| _evt.webkitMovementX
+		|| _evt.msMovementX
+		|| 0;
+
+	g_MouseDeltaY = _evt.movementY
+		|| _evt.mozMovementY
+		|| _evt.webkitMovementY
+		|| _evt.msMovementY
+		|| 0;
 
 	// Keep the current input events updated        		
 	g_CurrentInputEvents[_evt.button].x = g_EventMouseX;
@@ -1068,6 +1083,14 @@ function    yyIOManager( )
 
 }
 
+function onMouseLockChange()
+{
+	g_MouseLocked = (document.pointerLockElement === canvas
+		|| document.mozPointerLockElement === canvas
+		|| document.webkitPointerLockElement === canvas
+		|| document.msPointerLockElement === canvas);
+}
+
 function browser_input_capture( _enable )
 {
     _enable = yyGetBool(_enable);
@@ -1099,6 +1122,11 @@ function browser_input_capture( _enable )
         window.addEventListener("focus", yySetINFocus);
         window.addEventListener("blur", yySetOUTFocus);
 
+		document.onpointerlockchange = onMouseLockChange;
+		document.onmozpointerlockchange = onMouseLockChange;
+		document.onwebkitpointerlockchange = onMouseLockChange;
+		document.onmspointerlockchange = onMouseLockChange;
+		
         // IE, Chrome, FireFox and Safari
       
         CaptureBrowserInput();
@@ -1131,6 +1159,11 @@ function browser_input_capture( _enable )
         window.onfocus = null;
         window.onblur = null;
 
+		document.onpointerlockchange = null;
+		document.onmozpointerlockchange = null;
+		document.onwebkitpointerlockchange = null;
+		document.onmspointerlockchange = null;
+		
         // IE, Chrome, FireFox and Safari
        
         ReleaseBrowserInput();


### PR DESCRIPTION
Adding new functions:

* `window_mouse_set_locked(enable) -> Undefined`, which enables/disable mouse lock. When mouse lock is enabled, the mouse cursor is hidden and locked at the center of the window. When disabled, the cursor is shown again and unlocked. While locked, you can still use functions `window_mouse_get_delta_x()` and `window_mouse_get_delta_y()` to check how much has the mouse moved since the last frame.
* `window_mouse_get_locked() -> Bool`, which checks whether the mouse is locked.
* `window_mouse_get_delta_x() -> Real`, which returns how many pixels has the mouse moved on the x axis since the last frame.
* `window_mouse_get_delta_y() -> Real`, which returns how many pixels has the mouse moved on the y axis since the last frame.

Issue link: https://bugs.opera.com/browse/GM-5939
