### PR TITLE
GM-7389: Global space particles mode

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -1132,3 +1132,8 @@ function part_system_layer(_ind, _layerid)
     var ret = ParticleSystem_Layer(yyGetInt32(_ind), layer.m_id);
     return ret;
 }
+
+function part_system_global_space(_ind, _enable)
+{
+    ParticleSystem_GlobalSpace(yyGetInt32(_ind), yyGetBool(_enable));
+}

--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -36,6 +36,7 @@ function particle_get_info(_ind)
         variable_struct_set(pPSI, "xorigin", pPS.originX);
         variable_struct_set(pPSI, "yorigin", pPS.originY);
         variable_struct_set(pPSI, "oldtonew", (pPS.drawOrder == 0));
+        variable_struct_set(pPSI, "global_space", pPS.globalSpaceParticles);
 
         var emittersArray = [];
         for (var i = 0; i < pPS.emitters.length; ++i)

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -2414,7 +2414,6 @@ function HandleLife( _ps, _em )
 				if ( YYRandom(-numb) == 0 ) numb = 1;
 			}
 			if  ( numb > 0 ){
-				console.log("EMIT!", pParticle.x, pParticle.y);
 				EmitParticles(pPartSys, pEmitter, pParticle.x, pParticle.y, pParType.deathtype, numb);
 			}
 			pParticles.splice(i,1);	// remove particle

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -263,6 +263,7 @@ function CParticleSystem()
 	this.originX = 0;
 	this.originY = 0;
 	this.drawOrder = 0;
+	this.globalSpaceParticles = false;
 
 	/// The index within instances where the particle system is stored.
 	this.index = -1;
@@ -295,6 +296,7 @@ CParticleSystem.CreateFromJSON = function (json)
 	system.originX = json.originX;
 	system.originY = json.originY;
 	system.drawOrder = json.drawOrder;
+	system.globalSpaceParticles = json.globalSpaceParticles;
 	for (var i = 0; i < json.emitters.length; ++i)
 	{
 		system.emitters.push(json.emitters[i]);
@@ -371,6 +373,7 @@ CParticleSystem.prototype.MakeInstance = function (_layerID, _persistent, _pPart
 
 	var system = g_ParticleSystems[ps];
 	system.oldtonew = (this.drawOrder == 0);
+	system.globalSpaceParticles = this.globalSpaceParticles;
 
 	for (var i = this.emitters.length - 1; i >= 0; --i)
 	{

--- a/scripts/yyRoom.js
+++ b/scripts/yyRoom.js
@@ -2068,6 +2068,7 @@ yyRoom.prototype.DrawLayerParticleSystem = function(_rect,_layer,_el)
 	matWorldNew.Translation(pSystem.xdraw + _el.m_x, pSystem.ydraw + _el.m_y, 0.0);
 
 	WebGL_SetMatrix(MATRIX_WORLD, matWorldNew);
+	ParticleSystem_SetMatrix(ps, matWorldNew);
 	ParticleSystem_Draw(ps, _el.m_imageBlend, _el.m_imageAlpha);
 	WebGL_SetMatrix(MATRIX_WORLD, matWorldOld);
 };

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -5011,6 +5011,8 @@ yySequenceManager.prototype.HandleParticleTrackUpdate = function (_pEl, _pSeq, _
 
         if (ps != -1)
         {
+            ParticleSystem_SetMatrix(ps, _matrix);
+
             // Re-burst emitters when the sequence loops
 			if (_pInst.m_wrapped)
 			{


### PR DESCRIPTION
Added new function `part_system_global_space(ps, enable)`, using which you can enable global space particles. When enabled, particles keep their position and direction when the particle system is moved or rotated. Function `particle_get_info(partsys)` now also returns a new "global_space" key, which tells whether the particle system resource has global space particles enabled or not.

Issue link: https://bugs.opera.com/browse/GM-7389

