### PR TITLE
GM-7498: Relative/density based mode for particle emitters

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -49,6 +49,7 @@ function particle_get_info(_ind)
             variable_struct_set(pEmitterI, "name", templateEmitter.name);
             variable_struct_set(pEmitterI, "mode", templateEmitter.mode);
             variable_struct_set(pEmitterI, "number", templateEmitter.number);
+            variable_struct_set(pEmitterI, "relative", templateEmitter.relative);
             variable_struct_set(pEmitterI, "xmin", templateEmitter.xmin);
             variable_struct_set(pEmitterI, "xmax", templateEmitter.xmax);
             variable_struct_set(pEmitterI, "ymin", templateEmitter.ymin);
@@ -948,6 +949,19 @@ var part_emitter_burst = ParticleSystem_Emitter_Burst;
 // #############################################################################################
  var part_emitter_stream = ParticleSystem_Emitter_Stream;
 
+// #############################################################################################
+/// Function:<summary>
+///          	Enable or disable relative/density based mode.
+///          </summary>
+///
+/// In:		<param name="_ps"></param>
+///			<param name="_ind"></param>
+///			<param name="_enable"></param>
+/// Out:	<returns>
+///				
+///			</returns>
+// #############################################################################################
+var part_emitter_relative = ParticleSystem_Emitter_Relative;
 
 // #############################################################################################
 /// Function:<summary>

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -1573,20 +1573,16 @@ function	ParticleSystem_Emitter_Region(_ps, _ind, _xmin, _xmax, _ymin, _ymax, _s
 	pEmitter.posdistr = yyGetInt32(_posdistr);
 }
 
-function EmitterGetNumber(emitter)
+function EmitterGetNumber(_emitter)
 {
-	if (!emitter.relative)
+	if (!_emitter.relative)
 	{
-		return emitter.number;
+		return _emitter.number;
 	}
 
-	// FIXME: Formula for density based emitters
-	var width = Math.abs(emitter.xmax - emitter.xmin);
-	var height = Math.abs(emitter.ymax - emitter.ymin);
-	var area = width * height;
-	var res = 32 * 32;
-
-	return ~~(area * 1/res * emitter.number);
+	var width = Math.abs(_emitter.xmax - _emitter.xmin);
+	var height = Math.abs(_emitter.ymax - _emitter.ymin);
+	return width * height * _emitter.number * 0.00003;
 }
 
 function EmitParticles(_system, _emitter, _x, _y, _parttype, _numb, _applyColor, _col)
@@ -1649,6 +1645,14 @@ function	ParticleSystem_Emitter_Burst_Impl(
 		}
 	}
 	
+	var fract = _numb - ~~_numb;
+	_numb = ~~_numb;
+
+	if (fract > 0.0 && Math.random() <= fract)
+	{
+		_numb += 1.0;
+	}
+
 	var pos = new Vector3(_x, _y, 0);
 	var right = new Vector3(_width, 0, 0);
 	var down = new Vector3(0, _height, 0);
@@ -1755,7 +1759,7 @@ function	ParticleSystem_Emitter_Burst(_ps, _ind, _ptype, _numb)
 	var emitterHeight = emitter.ymax - emitter.ymin;
 	
 	_ptype = yyGetInt32(_ptype);
-	_numb = yyGetInt32(_numb);
+	_numb = yyGetReal(_numb);
 
 	ParticleSystem_Emitter_Burst_Impl(system, emitter, emitter.xmin, emitter.ymin,
 		emitterWidth, emitterHeight, emitter.shape, emitter.posdistr, _ptype, _numb);
@@ -1783,8 +1787,8 @@ function	ParticleSystem_Emitter_Stream( _ps, _ind, _ptype, _numb)
 
 	var pEmitter = g_ParticleSystems[_ps].emitters[_ind];
 
-	pEmitter.number = yyGetInt32(_numb);
 	pEmitter.parttype = yyGetInt32(_ptype);
+	pEmitter.number = yyGetReal(_numb);
 }
 
 

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -5031,11 +5031,7 @@ yySequenceManager.prototype.HandleParticleTrackUpdate = function (_pEl, _pSeq, _
                             continue;
                         }
 
-                        var emitterNumber = EmitterGetNumber(emitter);
-                        if (emitterNumber != 0)
-                        {
-                            ParticleSystem_Emitter_Burst(ps, i, emitter.parttype, emitterNumber);
-                        }
+                        ParticleSystem_Emitter_Burst(ps, i, emitter.parttype, emitter.number);
                     }
                 }
 			}

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -5023,13 +5023,18 @@ yySequenceManager.prototype.HandleParticleTrackUpdate = function (_pEl, _pSeq, _
                     for (var i = 0; i < pEmitters.length; i++)
                     {
                         var emitter = pEmitters[i];
-                        if (!emitter.enabled) continue;
 
-                        if (emitter.created
-                            && emitter.mode == PT_MODE_BURST
-                            && emitter.number != 0)
+                        if (!emitter.enabled
+                            || !emitter.created
+                            || emitter.mode != PT_MODE_BURST)
                         {
-                            ParticleSystem_Emitter_Burst(ps, i, emitter.parttype, emitter.number);
+                            continue;
+                        }
+
+                        var emitterNumber = EmitterGetNumber(emitter);
+                        if (emitterNumber != 0)
+                        {
+                            ParticleSystem_Emitter_Burst(ps, i, emitter.parttype, emitterNumber);
                         }
                     }
                 }


### PR DESCRIPTION
Added new function `part_emitter_relative(ps,em,enable)` to enable/disable relative/density based mode for particle emitters, which means the number of particles they burst or stream becomes relative to their area.

Function `part_emitter_burst()` and `part_emitter_stream()` now also accept floats for number of particles to spawn - e.g. 1.5 will spawn 1 particle and another one with 50% chance, or 0.1 will spawn a particle with a 10% chance. This was required to make the implementation of density based emitters possible.

Function `particle_get_info()` was modified to include a new "relative" key for emitters, which is `true` or `false` based on whether the emitter has relative mode enabled or not.

Issue link: https://bugs.opera.com/browse/GM-7498
