### PR TITLE
GM-6885: Particle emitter delays and intervals

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -49,6 +49,12 @@ function particle_get_info(_ind)
             variable_struct_set(pEmitterI, "name", templateEmitter.name);
             variable_struct_set(pEmitterI, "mode", templateEmitter.mode);
             variable_struct_set(pEmitterI, "number", templateEmitter.number);
+            variable_struct_set(pEmitterI, "delay_min", templateEmitter.delayMin);
+            variable_struct_set(pEmitterI, "delay_max", templateEmitter.delayMax);
+            variable_struct_set(pEmitterI, "delay_unit", templateEmitter.delayUnit);
+            variable_struct_set(pEmitterI, "interval_min", templateEmitter.intervalMin);
+            variable_struct_set(pEmitterI, "interval_max", templateEmitter.intervalMax);
+            variable_struct_set(pEmitterI, "interval_unit", templateEmitter.intervalUnit);
             variable_struct_set(pEmitterI, "xmin", templateEmitter.xmin);
             variable_struct_set(pEmitterI, "xmax", templateEmitter.xmax);
             variable_struct_set(pEmitterI, "ymin", templateEmitter.ymin);
@@ -946,8 +952,39 @@ var part_emitter_burst = ParticleSystem_Emitter_Burst;
 ///				
 ///			</returns>
 // #############################################################################################
- var part_emitter_stream = ParticleSystem_Emitter_Stream;
+var part_emitter_stream = ParticleSystem_Emitter_Stream;
 
+// #############################################################################################
+/// Function:<summary>
+///          	
+///          </summary>
+///
+/// In:		<param name="_ps"></param>
+///			<param name="_ind"></param>
+///			<param name="_delay_min"></param>
+///			<param name="_delay_max"></param>
+///			<param name="_delay_unit"></param>
+/// Out:	<returns>
+///				
+///			</returns>
+// #############################################################################################
+var part_emitter_delay = ParticleSystem_Emitter_Delay;
+
+// #############################################################################################
+/// Function:<summary>
+///          	
+///          </summary>
+///
+/// In:		<param name="_ps"></param>
+///			<param name="_ind"></param>
+///			<param name="_interval_min"></param>
+///			<param name="_interval_max"></param>
+///			<param name="_interval_unit"></param>
+/// Out:	<returns>
+///				
+///			</returns>
+// #############################################################################################
+var part_emitter_interval = ParticleSystem_Emitter_Interval;
 
 // #############################################################################################
 /// Function:<summary>

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -168,12 +168,12 @@ function Emitter_Reset()
 	this.delayMin = 0;			// minimum delay before the first burst
 	this.delayMax = 0;			// maximum delay before the first burst
 	this.delayCurrent = 0;		// how much time is currently left before the first burst
-	this.delayUnit = 0;			// 0 = frames or 1 = seconds
+	this.delayUnit = 1;			// 0 = seconds or 1 = frames
 	
 	this.intervalMin = 0;		// minimum interval between bursts
 	this.intervalMax = 0;		// maximum interval between bursts
 	this.intervalCurrent = 0;	// how much time is currently left before the next burst
-	this.intervalUnit = 0;		// 0 = frames or 1 = seconds
+	this.intervalUnit = 1;		// 0 = seconds or 1 = frames
 	
 	this.parttype = 0;			// type of particles	
 	this.xmin = 0.0;			// the region in which to create particles
@@ -1797,7 +1797,7 @@ function EmitterRandomizeDelay(_emitter)
 		return;
 	}
 
-	_emitter.delayCurrent = (_emitter.delayUnit == 0)
+	_emitter.delayCurrent = (_emitter.delayUnit == 1)
 		? irandom_range(~~_emitter.delayMin, ~~_emitter.delayMax)
 		: random_range(_emitter.delayMin, _emitter.delayMax);
 }
@@ -1832,7 +1832,7 @@ function EmitterRandomizeInterval(_emitter)
 		return;
 	}
 
-	_emitter.intervalCurrent = (_emitter.intervalUnit == 0)
+	_emitter.intervalCurrent = (_emitter.intervalUnit == 1)
 		? irandom_range(~~_emitter.intervalMin, ~~_emitter.intervalMax)
 		: random_range(_emitter.intervalMin, _emitter.intervalMax);
 }
@@ -2686,8 +2686,8 @@ function ParticleSystem_Update(_ps)
 
 			if (pEmitter.delayCurrent > 0.0)
 			{
-				pEmitter.delayCurrent -= (pEmitter.delayUnit == 0)
-					? 1.0 : (g_pBuiltIn.delta_time * 0.001);
+				pEmitter.delayCurrent -= (pEmitter.delayUnit == 1)
+					? 1.0 : (g_pBuiltIn.delta_time * 0.000001);
 
 				if (pEmitter.delayCurrent <= 0.0)
 				{
@@ -2699,8 +2699,8 @@ function ParticleSystem_Update(_ps)
 
 			if (pEmitter.mode != PT_MODE_BURST)
 			{
-				pEmitter.intervalCurrent -= (pEmitter.intervalUnit == 0)
-					? 1.0 : (g_pBuiltIn.delta_time * 0.001);
+				pEmitter.intervalCurrent -= (pEmitter.intervalUnit == 1)
+					? 1.0 : (g_pBuiltIn.delta_time * 0.000001);
 
 				if (pEmitter.intervalCurrent <= 0.0)
 				{

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -5025,8 +5025,11 @@ yySequenceManager.prototype.HandleParticleTrackUpdate = function (_pEl, _pSeq, _
                         var emitter = pEmitters[i];
                         if (!emitter.enabled) continue;
 
+                        EmitterRandomizeDelay(emitter);
+
                         if (emitter.created
                             && emitter.mode == PT_MODE_BURST
+                            && emitter.delayCurrent <= 0.0
                             && emitter.number != 0)
                         {
                             ParticleSystem_Emitter_Burst(ps, i, emitter.parttype, emitter.number);


### PR DESCRIPTION
Added new functions `part_emitter_delay(ps,ind,delay_min,delay_max,delay_unit)` and `part_emitter_interval(ps,ind,interval_min,interval_max,interval_unit)` using which you can configure delay before an emitter burst first particles and interval between following bursts.

Function `particle_get_info()` now returns new keys "delay_min", "delay_max", "delay_unit", "interval_min", "interval_max" and "interval_unit" for emitters.

Issue link: https://bugs.opera.com/browse/GM-6885
