### PR TITLE
Fix TextBlock split function

### DIFF
--- a/scripts/yyFont.js
+++ b/scripts/yyFont.js
@@ -1810,9 +1810,9 @@ yyFontManager.prototype.Split_TextBlock_IDEstyle = function (_pStr, _boundsWidth
 	{ 
 		var yoffs = 0.0; 
 		if (alignmentV == TTALIGN_VCentre)		// middle 
-			yoffs = (boundsHeight - totalH) * 0.5; 
+			yoffs = (_boundsHeight - totalH) * 0.5; 
 		else if (alignmentV == TTALIGN_Bottom)	// bottom 
-			yoffs = (boundsHeight - totalH); 
+			yoffs = (_boundsHeight - totalH); 
  
 		if (yoffs != 0.0) 
 		{ 


### PR DESCRIPTION
Incorrectly spelled `boundsHeight` function argument changed to `_boundsHeight`.

Without that fix projects that have sequences with "wrap" text in them are not working.

