### PR TITLE
GM-8027: Fixed part_particles_burst creates particles for disabled emitters

### DIFF
--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -2056,6 +2056,9 @@ function ParticleSystem_Particles_Burst(_ps, _x, _y, _partsys)
 	{
 		var emitterIndex = asset.emitters[emitterCount - i - 1];
 		var emitter = g_PSEmitters[emitterIndex];
+
+		if (!emitter.enabled) continue;
+
 		var emitterWidth = emitter.xmax - emitter.xmin;
 		var emitterHeight = emitter.ymax - emitter.ymin;
 


### PR DESCRIPTION
Function `part_particles_burst` created particles even for emitters that were disabled in the Particle Editor.

Issue link: https://bugs.opera.com/browse/GM-8027
