### PR TITLE
GM-8024: Fixed part_emitter_burst creates particles for disabled emitters

### DIFF
--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -1836,6 +1836,9 @@ function	ParticleSystem_Emitter_Burst(_ps, _ind, _ptype, _numb)
 
 	var system = g_ParticleSystems[_ps];
 	var emitter = system.emitters[_ind];
+
+	if (!emitter.enabled) return;
+
 	var emitterWidth = emitter.xmax - emitter.xmin;
 	var emitterHeight = emitter.ymax - emitter.ymin;
 	


### PR DESCRIPTION
Function `part_emitter_burst` created particles even for emitters that were disabled with `part_emitter_enable(ps, em, false)`.

Issue link: https://bugs.opera.com/browse/GM-8024
