### PR TITLE
GM-8023: Fixed part_particles_burst doesn't create all particles when system has disabled emitters

### DIFF
--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -2048,9 +2048,16 @@ function ParticleSystem_Particles_Burst(_ps, _x, _y, _partsys)
 
 	var system = g_ParticleSystems[_ps];
 	var emitterCount = asset.emitters.length;
+	var emittersEnabled = [];
 
-	for (var i = emitterCount - system.emitters.length; i > 0; --i)
-		ParticleSystem_Emitter_Create(_ps);
+	for (var i = 0; i < system.emitters.length; ++i)
+	{
+		if (system.emitters[i].enabled)
+			emittersEnabled.push(i);
+	}
+
+	for (var i = emitterCount - emittersEnabled.length; i > 0; --i)
+		emittersEnabled.push(ParticleSystem_Emitter_Create(_ps));
 
 	for (var i = 0; i < emitterCount; ++i)
 	{
@@ -2059,7 +2066,7 @@ function ParticleSystem_Particles_Burst(_ps, _x, _y, _partsys)
 		var emitterWidth = emitter.xmax - emitter.xmin;
 		var emitterHeight = emitter.ymax - emitter.ymin;
 
-		ParticleSystem_Emitter_Burst_Impl(system, system.emitters[i], _x + emitter.xmin, _y + emitter.ymin,
+		ParticleSystem_Emitter_Burst_Impl(system, system.emitters[emittersEnabled[i]], _x + emitter.xmin, _y + emitter.ymin,
 			emitterWidth, emitterHeight, emitter.shape, emitter.posdistr, emitter.parttype, emitter.number);
 	}
 }


### PR DESCRIPTION
Function `part_particles_burst` did not create all particles if the target system had emitters disabled with `part_emitter_enable(ps, em, false)`.

Issue link: https://bugs.opera.com/browse/GM-8023
