### PR TITLE
GM-8011: Moving particle systems to references

### DIFF
--- a/scripts/functions/Function_Game.js
+++ b/scripts/functions/Function_Game.js
@@ -14,20 +14,6 @@
 // 25/02/2011		V1.0        MJD     1st version.
 // 
 // **********************************************************************************************************************
-var AT_Object = 0,
-	AT_Sprite = 1,
-	AT_Sound = 2,
-	AT_Room = 3,
-	AT_Background = 4,
-	AT_Path = 5,
-	AT_Script = 6,
-	AT_Font = 7,
-	AT_Timeline = 8,
-    AT_Tiles = 9, // In HTML5 tile resources are added as part of the background array
-	AT_Shader = 10,
-    AT_Sequence = 11,
-    AT_AnimCurve = 12;
-    AT_ParticleSystem = 13;
 
 var TimingMethod = 1;       //tm_countvsyncs=1, tm_sleep=0
 

--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -27,16 +27,7 @@ function GetParticleSystemResourceIndex(_arg)
 
 function GetParticleSystemInstanceIndex(_arg, _optional)
 {
-    var index = yyGetInt32(_arg);
-
-    // UGH... Based on docs, indices 0 and 1 are supposed to be reserved for
-    // particle systems used by the effect_create_above and effect_create_below
-    // functions, se we need to have an exception for these...
-    if (index != 0 && index != 1)
-    {
-        index -= PART_SYSTEM_START_ID;
-    }
-
+    var index = yyGetInt32(_arg) - PART_SYSTEM_START_ID;
     if (!_optional)
     {
         if (index < 0 || index >= g_ParticleSystems.length || !g_ParticleSystems[index])
@@ -44,7 +35,6 @@ function GetParticleSystemInstanceIndex(_arg, _optional)
             YYError("invalid reference to particle system instance");
         }
     }
-
     return index;
 }
 

--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -549,6 +549,7 @@ var part_particles_create_colour = part_particles_create_color;
 function part_particles_burst(_ind, _x, _y, _partsys)
 {
     _ind = GetParticleSystemInstanceIndex(_ind);
+    _partsys = GetParticleSystemResourceIndex(_partsys);
     return ParticleSystem_Particles_Burst(_ind, _x, _y, _partsys);
 }
 
@@ -1045,6 +1046,7 @@ function part_type_life(_ind, _life_min, _life_max)
 function part_type_step(_ind, _step_number, _step_type)
 {
     _ind = GetParticleTypeIndex(_ind);
+    _step_type = GetParticleTypeIndex(_step_type, true);
     return ParticleType_Step(_ind, _step_number, _step_type);
 }
 
@@ -1067,6 +1069,7 @@ function part_type_step(_ind, _step_number, _step_type)
 function part_type_death(_ind, _death_number, _death_type)
 {
     _ind = GetParticleTypeIndex(_ind);
+    _death_type = GetParticleTypeIndex(_death_type, true);
     return ParticleType_Death(_ind, _death_number, _death_type);
 }
 
@@ -1316,7 +1319,7 @@ function part_emitter_burst(_ps, _ind, _parttype, _number)
     _ps = GetParticleSystemInstanceIndex(_ps);
     _ind = GetParticleEmitterIndex(_ps, _ind);
     _parttype = GetParticleTypeIndex(_parttype);
-    ParticleSystem_Emitter_Burst(_ps, _ind, _parttype, _number);
+    return ParticleSystem_Emitter_Burst(_ps, _ind, _parttype, _number);
 }
 
 // #############################################################################################
@@ -1559,5 +1562,5 @@ function part_system_layer(_ind, _layerid)
 function part_system_global_space(_ind, _enable)
 {
     _ind = GetParticleSystemInstanceIndex(_ind);
-    ParticleSystem_GlobalSpace(_ind, yyGetBool(_enable));
+    return ParticleSystem_GlobalSpace(_ind, _enable);
 }

--- a/scripts/physics/yyPhysicsWorld.js
+++ b/scripts/physics/yyPhysicsWorld.js
@@ -757,7 +757,7 @@ yyPhysicsWorld.prototype.CreateBody = function (_pFixture, _pInst, _xoffs, _yoff
 	// Don't just blow up if they've screwed up the setup
 	if (fixtureDef.shape == null) {
 		var err = "No fixture shape data present for " + _pInst.GetObj().GetName() + "\n";
-		YYError(err, true);
+		yyError(err, true);
 	}
 	else {
 		var collisionCategory = this.BuildCollisionBits(_pInst.object_index);

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -248,6 +248,8 @@ function yyParticleSystem()
 /**@constructor*/
 function ParticleSystem_ClearClass()
 {
+	this.m_resourceID = -1;					// the id of the particle system resource that this system was created from
+
 	this.created = false;					// whether created
 	
 	this.emitters = []; 						// the emitters
@@ -388,6 +390,7 @@ CParticleSystem.prototype.MakeInstance = function (_layerID, _persistent, _pPart
 	}
 
 	var system = g_ParticleSystems[ps];
+	system.m_resourceID = this.index;
 	system.oldtonew = (this.drawOrder == 0);
 	system.globalSpaceParticles = this.globalSpaceParticles;
 
@@ -400,6 +403,7 @@ CParticleSystem.prototype.MakeInstance = function (_layerID, _persistent, _pPart
 		var em = ParticleSystem_Emitter_Create(ps);
 		var instanceEmitter = system.emitters[em];
 
+		instanceEmitter.name = templateEmitter.name;
 		instanceEmitter.enabled = templateEmitter.enabled;
 		instanceEmitter.mode = templateEmitter.mode;
 		instanceEmitter.number = templateEmitter.number;

--- a/scripts/yyTypes.js
+++ b/scripts/yyTypes.js
@@ -14,6 +14,109 @@
 // 
 // **********************************************************************************************************************
 
+var AT_Object = 0,
+	AT_Sprite = 1,
+	AT_Sound = 2,
+	AT_Room = 3,
+	AT_Background = 4,
+	AT_Path = 5,
+	AT_Script = 6,
+	AT_Font = 7,
+	AT_Timeline = 8,
+    AT_Tiles = 9, // In HTML5 tile resources are added as part of the background array
+	AT_Shader = 10,
+    AT_Sequence = 11,
+    AT_AnimCurve = 12;
+    AT_ParticleSystem = 13;
+
+var REFCAT_RESOURCE			= 0x01000000;
+var REFCAT_DATA_STRUCTURE	= 0x02000000;
+var REFCAT_INSTANCE			= 0x04000000;
+
+// Runtime instances of resources
+var REFID_INSTANCE			= (0x00000001 | REFCAT_INSTANCE);
+var REFID_DBG				= (0x00000002 | REFCAT_INSTANCE);
+var REFID_PART_SYSTEM		= (0x00000004 | REFCAT_INSTANCE);
+var REFID_PART_EMITTER		= (0x00000008 | REFCAT_INSTANCE);
+var REFID_PART_TYPE			= (0x00000010 | REFCAT_INSTANCE);
+
+// 
+var REFID_OBJECT			= (AT_Object | REFCAT_RESOURCE);
+var REFID_SPRITE			= (AT_Sprite | REFCAT_RESOURCE);
+var REFID_SOUND				= (AT_Sound | REFCAT_RESOURCE);
+var REFID_ROOM				= (AT_Room | REFCAT_RESOURCE);
+var REFID_BACKGROUND		= (AT_Background | REFCAT_RESOURCE);
+var REFID_PATH				= (AT_Path | REFCAT_RESOURCE);
+var REFID_SCRIPT			= (AT_Script | REFCAT_RESOURCE);
+var REFID_FONT				= (AT_Font | REFCAT_RESOURCE);
+var REFID_TIMELINE			= (AT_Timeline | REFCAT_RESOURCE);
+var REFID_TILES				= (AT_Tiles | REFCAT_RESOURCE);
+var REFID_SHADER			= (AT_Shader | REFCAT_RESOURCE);
+var REFID_SEQUENCE			= (AT_Sequence | REFCAT_RESOURCE);
+var REFID_ANIMCURVE			= (AT_AnimCurve | REFCAT_RESOURCE);
+var REFID_PARTICLESYSTEM	= (AT_ParticleSystem | REFCAT_RESOURCE);
+
+var REFID_DS_LIST		= (0x00000001 | REFCAT_DATA_STRUCTURE);
+var REFID_DS_MAP		= (0x00000002 | REFCAT_DATA_STRUCTURE);
+var REFID_DS_GRID		= (0x00000004 | REFCAT_DATA_STRUCTURE);
+var REFID_DS_QUEUE		= (0x00000008 | REFCAT_DATA_STRUCTURE);
+var REFID_DS_STACK		= (0x00000010 | REFCAT_DATA_STRUCTURE);
+var REFID_DS_PRIORITY	= (0x00000020 | REFCAT_DATA_STRUCTURE);
+
+function YYRef(_type, _index)
+{
+    this.type = _type;
+    this.index = _index;
+}
+
+function MAKE_REF(a, b)
+{
+    return new YYRef(a, b);
+}
+
+function YYASSET_REF(a)
+{
+    var index = a & 0x00ffffff;
+    var type = (a >> 24) & 0xff | REFCAT_RESOURCE;
+    return MAKE_REF(type, index);
+}
+
+function RefName(_ref)
+{
+    var pRet = "unknown";
+    switch (_ref)
+    {
+    case REFID_INSTANCE:	pRet = "instance";  break;
+    case REFID_DS_LIST:		pRet = "ds_list"; break;
+    case REFID_DS_MAP:		pRet = "ds_map"; break;
+    case REFID_DS_GRID:		pRet = "ds_grid"; break;
+    case REFID_DS_QUEUE:	pRet = "ds_queue"; break;
+    case REFID_DS_STACK:	pRet = "ds_stack"; break;
+    case REFID_DS_PRIORITY:	pRet = "ds_priority"; break;
+    case REFID_OBJECT:		pRet = "object"; break;
+    case REFID_SPRITE:		pRet = "sprite"; break;
+    case REFID_SOUND:		pRet = "sound"; break;
+    case REFID_ROOM:		pRet = "room"; break;
+    case REFID_BACKGROUND:	pRet = "background"; break;
+    case REFID_PATH:		pRet = "path"; break;
+    case REFID_SCRIPT:		pRet = "script"; break;
+    case REFID_FONT:		pRet = "font"; break;
+    case REFID_TIMELINE:	pRet = "timeline"; break;
+    case REFID_TILES:		pRet = "tiles"; break;
+    case REFID_SHADER:		pRet = "shader"; break;
+    case REFID_SEQUENCE:	pRet = "sequence"; break;
+    case REFID_ANIMCURVE:	pRet = "animcurve"; break;
+    case REFID_PARTICLESYSTEM:		pRet = "particle system resource"; break;
+    case REFID_DBG:			pRet = "dbgref"; break;
+    case REFID_PART_SYSTEM:	pRet = "particle system instance"; break;
+    case REFID_PART_EMITTER:pRet = "particle emitter"; break;
+    case REFID_PART_TYPE:	pRet = "particle type"; break;
+    default:
+        break;
+    } // end switch
+    return pRet;
+} // end RefName
+
 // #############################################################################################
 /// Function:<summary>
 ///				Converts the given type to a real number if required and returns the result.
@@ -26,7 +129,9 @@
 // #############################################################################################
 function yyGetReal(_v)
 {
-    if (typeof _v === "number")
+    if (_v instanceof YYRef)
+        return _v.index;
+    else if (typeof _v === "number")
         return _v;
     else if (typeof _v === "boolean") 
         return _v ? 1 : 0;
@@ -72,7 +177,9 @@ function yyGetReal(_v)
 ///			 </returns>
 // #############################################################################################
 function yyGetInt64(_v) {
-    if (typeof _v === "number")
+    if (_v instanceof YYRef)
+        return _v.index;
+    else if (typeof _v === "number")
         return Long.fromValue(_v, false);
     else if (typeof _v === "boolean") 
         return Long.fromValue(_v ? 1 : 0, false);
@@ -118,7 +225,9 @@ function yyGetInt64(_v) {
 ///			 </returns>
 // #############################################################################################
 function yyGetInt32(_v) {
-    if (typeof _v === "number")
+    if (_v instanceof YYRef)
+        return _v.index;
+    else if (typeof _v === "number")
         return ~~_v;
     else if (typeof _v === "boolean") 
         return _v ? 1 : 0;
@@ -164,7 +273,9 @@ function yyGetInt32(_v) {
 ///			 </returns>
 // #############################################################################################
 function yyGetBool(_v) {
-    if (typeof _v === "boolean") 
+    if (_v instanceof YYRef)
+        return _v.index > 0;
+    else if (typeof _v === "boolean") 
         return _v;
     else if (_v === undefined) 
         return false;
@@ -211,6 +322,27 @@ function yyGetBool(_v) {
     return false;
 }
 
+function yyGetRef(_value, _ref, _maxNum, _array, _allowOutOfRange) {
+    var ret = -1;
+    if (_value instanceof YYRef) {
+        var type = _value.type;
+        if (type != _ref) {
+            yyError("incorrect type (" + RefName(type) + ") expecting a " + RefName(_ref));
+        }
+        ret = _value.index;
+    }
+    else {
+        ret = yyGetInt32(_value);
+    }
+
+    if (!_allowOutOfRange) {
+        if (ret < 0 || ret >= _maxNum || (_array && !_array[ret])) {
+            yyError("invalid reference to (" + RefName(_ref) + ")");
+        }
+    }
+
+    return ret;
+}
 
 // #############################################################################################
 /// Function:<summary>
@@ -247,7 +379,9 @@ function STRING_RemoveVisited( _v )
 
 
 function yyGetString(_v) {
-    if (typeof _v === "string") {
+    if (_v instanceof YYRef)
+        return "ref " + _v.index;
+    else if (typeof _v === "string") {
         var ret = "";
         if (g_incQuotesSTRING_RValue > 0)
             ret += "\"";

--- a/scripts/yyTypes.js
+++ b/scripts/yyTypes.js
@@ -63,10 +63,10 @@ var REFID_DS_QUEUE		= (0x00000008 | REFCAT_DATA_STRUCTURE);
 var REFID_DS_STACK		= (0x00000010 | REFCAT_DATA_STRUCTURE);
 var REFID_DS_PRIORITY	= (0x00000020 | REFCAT_DATA_STRUCTURE);
 
-function YYRef(_type, _index)
+function YYRef(_type, _value)
 {
     this.type = _type;
-    this.index = _index;
+    this.value = _value;
 }
 
 function MAKE_REF(a, b)
@@ -139,7 +139,7 @@ function RefName(_ref)
 function yyGetReal(_v)
 {
     if (_v instanceof YYRef)
-        return _v.index;
+        return _v.value;
     else if (typeof _v === "number")
         return _v;
     else if (typeof _v === "boolean") 
@@ -187,7 +187,7 @@ function yyGetReal(_v)
 // #############################################################################################
 function yyGetInt64(_v) {
     if (_v instanceof YYRef)
-        return _v.index;
+        return _v.value;
     else if (typeof _v === "number")
         return Long.fromValue(_v, false);
     else if (typeof _v === "boolean") 
@@ -235,7 +235,7 @@ function yyGetInt64(_v) {
 // #############################################################################################
 function yyGetInt32(_v) {
     if (_v instanceof YYRef)
-        return _v.index;
+        return _v.value;
     else if (typeof _v === "number")
         return ~~_v;
     else if (typeof _v === "boolean") 
@@ -283,7 +283,7 @@ function yyGetInt32(_v) {
 // #############################################################################################
 function yyGetBool(_v) {
     if (_v instanceof YYRef)
-        return _v.index > 0;
+        return _v.value > 0;
     else if (typeof _v === "boolean") 
         return _v;
     else if (_v === undefined) 
@@ -338,7 +338,7 @@ function yyGetRef(_value, _ref, _maxNum, _array, _allowOutOfRange) {
         if (type != _ref) {
             yyError("incorrect type (" + RefName(type) + ") expecting a " + RefName(_ref));
         }
-        ret = _value.index;
+        ret = _value.value;
     }
     else {
         ret = yyGetInt32(_value);
@@ -389,7 +389,7 @@ function STRING_RemoveVisited( _v )
 
 function yyGetString(_v) {
     if (_v instanceof YYRef)
-        return "ref " + _v.index;
+        return "ref " + _v.value;
     else if (typeof _v === "string") {
         var ret = "";
         if (g_incQuotesSTRING_RValue > 0)

--- a/scripts/yyTypes.js
+++ b/scripts/yyTypes.js
@@ -78,7 +78,16 @@ function YYASSET_REF(a)
 {
     var index = a & 0x00ffffff;
     var type = (a >> 24) & 0xff | REFCAT_RESOURCE;
-    return MAKE_REF(type, index);
+
+    switch (type)
+    {
+    // TODO: Move resources to references
+    case REFID_PARTICLESYSTEM:
+        return MAKE_REF(type, index);
+    
+    default:
+        return index;
+    }
 }
 
 function RefName(_ref)


### PR DESCRIPTION
* Brought in `REFID_` macros from the C++ runner.
* Added new class `YYRef` for typed references.
* Added function `MAKE_REF`, using which you can make a typed reference.
* Added function `YYASSET_REF`  for making references to resources. Currently actually returns a `YYRef` only for Particle System resources and just the index (number) for the rest.
* Added `RefName` which retrieves a name for given reference type.
* All `yyGetSomething` now take `YYRef` into account.
* Added `yyGetRef` similar to its C++ counterpart.
* Moved particle systems, emitters and types to references for better error checking and making possible to use `particle_get_info()` function also on particle systems created with `part_system_create()`. All `part_` functions now validate inputs (types, existing resources like sprites, layers etc.).

Issue link: https://bugs.opera.com/browse/GM-8011
