### PR TITLE
layer_element_move typo bug fixes

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -4148,7 +4148,7 @@ function layer_element_move(_elid, _targetlayerID) {
         return -1;
     }
 
-    var targetlayer = g_pLayerManager.GetLayerFromID(yyGetInt32(_targetlayerID));
+    var targetlayer = g_pLayerManager.GetLayerFromID(room, yyGetInt32(_targetlayerID));
     if (targetlayer != null)
     {
         g_pLayerManager.MoveElement(room, elandlay.element, targetlayer);

--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -537,7 +537,7 @@ LayerManager.prototype.MoveElement = function(_room, _element, _targetlayer)
     if (_room == null)
         return;
 
-    if (_element = null)
+    if (_element == null)
         return;
 
     if (_targetlayer == null)


### PR DESCRIPTION
1. Wrong number of args for GetLayerFromID
2. Typo in null check resulting in element being assigned null