### PR TITLE
GM-8158: Splash screen not working in HTML5

### DIFF
--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -844,17 +844,24 @@ function animate() {
                     done = false;
                 }
                 ProcessFileLoading();
+                var _loadingBarCallback = g_LoadingBarCallback;
                 if(g_pGMFile.Options.loadingBarCallback)
                 {
                     if (g_ExtensionTotal == g_ExtensionCount)
                     {
-                        g_CustomLoadingBarCallback = eval(g_pGMFile.Options.loadingBarCallback);
-                        g_CustomLoadingBarCallback(g_LoadGraphics, DISPLAY_WIDTH, DISPLAY_HEIGHT, g_LoadingTotal, g_LoadingCount, g_LoadingScreen);
+                        try
+                        {
+                            _loadingBarCallback = eval(g_pGMFile.Options.loadingBarCallback);
+                            g_CustomLoadingBarCallback = _loadingBarCallback;
+                        }
+                        catch (_err)
+                        {
+                            console.error('Invalid loading bar extension "' + g_pGMFile.Options.loadingBarCallback + '", using default!');
+                            console.dir(_err);
+                        }
                     }
-					
                 }
-                else
-                    g_LoadingBarCallback(g_LoadGraphics, DISPLAY_WIDTH, DISPLAY_HEIGHT, g_LoadingTotal, g_LoadingCount, g_LoadingScreen);
+                _loadingBarCallback(g_LoadGraphics, DISPLAY_WIDTH, DISPLAY_HEIGHT, g_LoadingTotal, g_LoadingCount, g_LoadingScreen);
                 //g_LoadingCount++;
                 break;
 


### PR DESCRIPTION
IDE incorrectly stored a localized string into HTML5 option for a custom loading bar, which meant even the default loading bar didn't work because it was a different string than expected. I'm fixing this on the IDE and asset compiler side as well, but this at least gives a more sensible error message when the option is wrong and reverts to the default loading bar callback,

Issue link: https://bugs.opera.com/browse/GM-8158
