### PR TITLE
GM-8205: tag_get_assets() not working for Particle System assets

### DIFF
--- a/scripts/functions/Function_Game.js
+++ b/scripts/functions/Function_Game.js
@@ -1705,6 +1705,10 @@ function ResourceGetName( _index, _assetType )
         case AT_Shader:	        return ( shader_exists(_index)) ? shader_get_name(_index) : "";
         case AT_Sequence:	    return ( _sequence_exists(_index)) ? sequence_get_name(_index) : "";
         case AT_AnimCurve:	    return ( _animcurve_exists(_index)) ? animcurve_get_name(_index) : "";
+        case AT_ParticleSystem:	{
+            var ps = CParticleSystem.Get(_index);
+            return (ps != null) ? ps.name : "";
+        }
     }
     return "";
 }


### PR DESCRIPTION
The data was there but `ResourceGetName` didn't work for Particle System assets.

Issue link: https://bugs.opera.com/browse/GM-8205
