### PR TITLE
GM-8180: part_type_death() does not work with negative numbers

### DIFF
--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -2675,7 +2675,7 @@ function HandleLife( _ps, _em )
 		{
 			numb = pParType.deathnumber;
 			if ( numb<0 ){
-				if ( YYRandom(-numb) == 0 ) numb = 1;
+				if ( ~~YYRandom(-numb) == 0 ) numb = 1;
 			}
 			if  ( numb > 0 ){
 				EmitParticles(pPartSys, pEmitter, pParticle.x, pParticle.y, pParType.deathtype, numb);
@@ -2685,7 +2685,7 @@ function HandleLife( _ps, _em )
 			// Create step particles
 			numb = pParType.stepnumber;
 			if ( numb<0 ){
-				if ( YYRandom(-numb) == 0 ) numb = 1;
+				if ( ~~YYRandom(-numb) == 0 ) numb = 1;
 			}
 			if ( numb > 0 ){
 				EmitParticles(pPartSys, pEmitter, pParticle.x, pParticle.y, pParType.steptype, numb);


### PR DESCRIPTION
Issue link: https://bugs.opera.com/browse/GM-8180
