### PR TITLE
GM-7986: Fixed black screen when drawing small nineslice sprites over big areas

### DIFF
--- a/scripts/yyNineSliceData.js
+++ b/scripts/yyNineSliceData.js
@@ -752,7 +752,7 @@ yyNineSliceData.prototype.DrawFromCache = function (_x, _y, _rot, _colour, _alph
     var a = (_alpha * 255.0) << 24;
     var _col = a | _colour;
 
-    var maxtrisinrun = DEFAULT_VB_SIZE / 3;     // not sure if this is actually the max we support but it's a reasonable value
+    var maxtrisinrun = ~~(DEFAULT_VB_SIZE / 3);     // not sure if this is actually the max we support but it's a reasonable value
     var trisremaining = (this.cache.verts.length / 2) / 3;
 
     var srcvert = this.cache.verts;


### PR DESCRIPTION
Issue link: https://bugs.opera.com/browse/GM-7986
