### PR TITLE
Issue 1114: Added vertex buffer update functions

### DIFF
--- a/scripts/Builders/yyVBufferBuilder.js
+++ b/scripts/Builders/yyVBufferBuilder.js
@@ -92,20 +92,22 @@ function yyVBufferBuilder(_size) {
 
     // #############################################################################################
     /// Function:<summary>
-    ///             Resizes the buffer 
+    ///             Resizes the buffer if its size is different than the size provided.
     ///          </summary>
     // #############################################################################################
     /** @this {yyVBufferBuilder} */	
     this.Resize = function (_size) {
-
-        var arrayBufferReplacement = new ArrayBuffer(_size);
-    					    					    
-        var oldBufferView = new Int8Array(m_arrayBuffer);
-        var newbufferView = new Int8Array(arrayBufferReplacement);
-        newbufferView.set(oldBufferView);
-        
-        m_arrayBuffer = arrayBufferReplacement;
-        m_dataView = new DataView(m_arrayBuffer);
+        if (m_arrayBuffer.byteLength != _size)
+        {
+            var arrayBufferReplacement = new ArrayBuffer(_size);
+                                                        
+            var oldBufferView = new Int8Array(m_arrayBuffer);
+            var newbufferView = new Int8Array(arrayBufferReplacement);
+            newbufferView.set(oldBufferView);
+            
+            m_arrayBuffer = arrayBufferReplacement;
+            m_dataView = new DataView(m_arrayBuffer);
+        }
     };
 
     // #############################################################################################

--- a/scripts/Builders/yyVBufferBuilder.js
+++ b/scripts/Builders/yyVBufferBuilder.js
@@ -143,6 +143,10 @@ function yyVBufferBuilder(_size) {
     };
     
     this.GetFVF = function () { return m_FVF; };
+    this.SetFVF = function (_fvf) {
+        m_FVF = _fvf;
+        m_vertexFormat = g_webGL.GetVertexFormat(_fvf);
+    };
     this.GetFormat = function () { return g_webGL.GetVertexFormat(m_FVF); };
 
     // #############################################################################################

--- a/scripts/libWebGL/yyVertexFormat.js
+++ b/scripts/libWebGL/yyVertexFormat.js
@@ -218,4 +218,22 @@ function yyVertexFormat() {
         }
         return true;
     };
+
+    // #############################################################################################
+    /// Function:<summary>
+    ///             Retrieves size of given vertex format element type.
+    ///          </summary>
+    // #############################################################################################
+    /** @this {yyVertexFormat} */
+    this.GetTypeSize = function (_type) {
+        switch (_type) {
+            case yyGL.VT_FLOAT1: return 4;
+            case yyGL.VT_FLOAT2: return 8;
+            case yyGL.VT_FLOAT3: return 12;
+            case yyGL.VT_FLOAT4: return 16;
+            case yyGL.VT_COLOR:  return 4;
+            case yyGL.VT_UBYTE4: return 4;
+            default: return 0;
+        }
+    };
 }

--- a/scripts/libWebGL/yyVertexFormat.js
+++ b/scripts/libWebGL/yyVertexFormat.js
@@ -233,7 +233,38 @@ function yyVertexFormat() {
             case yyGL.VT_FLOAT4: return 16;
             case yyGL.VT_COLOR:  return 4;
             case yyGL.VT_UBYTE4: return 4;
-            default: return 0;
+            default:
+                return 0;
         }
+    };
+
+    // TODO: put this stuff in lookup tables
+
+    /** @this {yyVertexFormat} */
+    this.GetNumElementsInType = function (_type) {
+        switch(_type) {
+            case yyGL.VT_FLOAT1: return 1;
+            case yyGL.VT_FLOAT2: return 2;
+            case yyGL.VT_FLOAT3: return 3;
+            case yyGL.VT_FLOAT4: return 4;
+            case yyGL.VT_COLOR:  return 1;
+            case yyGL.VT_UBYTE4: return 1;
+            default:
+                return 0;
+        };
+    };
+
+    /** @this {yyVertexFormat} */
+    this.GetElementSizeInType = function (_type) {
+        switch(_type) {
+            case yyGL.VT_FLOAT1: return 4;
+            case yyGL.VT_FLOAT2: return 4;
+            case yyGL.VT_FLOAT3: return 4;
+            case yyGL.VT_FLOAT4: return 4;
+            case yyGL.VT_COLOR:  return 4;
+            case yyGL.VT_UBYTE4: return 4;
+            default:
+                return 0;
+        };
     };
 }

--- a/scripts/yyBufferVertex.js
+++ b/scripts/yyBufferVertex.js
@@ -210,6 +210,7 @@ function WebGL_vertex_update_buffer_from_buffer_ext(_buffer, _src_buffer, _forma
 
     // Create the new buffer and get it's class
     var pVBuffer = g_vertexBuffers[_buffer];
+    pVBuffer.Resize(total);
 
     // Now get the underlying arrays
     var srcbytebuff = new Uint8Array(pBuff.m_pRAWUnderlyingBuffer);     // src

--- a/scripts/yyBufferVertex.js
+++ b/scripts/yyBufferVertex.js
@@ -39,8 +39,8 @@ var vertex_get_number = function (buffer) { ErrorFunction("vertex_get_number"); 
 var vertex_get_buffer_size = function (buffer) { ErrorFunction("vertex_get_buffer_size"); };
 var vertex_create_buffer_from_buffer = function (buffer) { ErrorFunction("vertex_create_buffer_from_buffer"); };
 var vertex_create_buffer_from_buffer_ext = function (buffer) { ErrorFunction("vertex_create_buffer_from_buffer_ext"); };
-var vertex_update_buffer_from_buffer = function (buffer, src_buffer, format) { ErrorFunction("vertex_update_buffer_from_buffer"); };
-var vertex_update_buffer_from_buffer_ext = function (buffer, src_buffer, format, offset, num_vertices) { ErrorFunction("vertex_update_buffer_from_buffer_ext"); };
+var vertex_update_buffer_from_buffer = function (dest_vbuff, dest_offset, src_buffer, src_offset, src_size) { ErrorFunction("vertex_update_buffer_from_buffer"); };
+var vertex_update_buffer_from_vertex = function (dest_vbuff, dest_vert, src_vbuff, src_vert, src_vert_num) { ErrorFunction("vertex_update_buffer_from_vertex"); };
 var draw_flush = function () { };
 
 // Constant for the default vertex buffer storage size
@@ -62,7 +62,7 @@ function InitBufferVertexFunctions() {
     vertex_create_buffer_from_buffer = WebGL_vertex_create_buffer_from_buffer;
     vertex_create_buffer_from_buffer_ext = WebGL_vertex_create_buffer_from_buffer_ext;
     vertex_update_buffer_from_buffer = WebGL_vertex_update_buffer_from_buffer;
-    vertex_update_buffer_from_buffer_ext = WebGL_vertex_update_buffer_from_buffer_ext;
+    vertex_update_buffer_from_vertex = WebGL_vertex_update_buffer_from_vertex;
     vertex_delete_buffer = WebGL_vertex_delete_buffer_RELEASE;
     vertex_begin = WebGL_vertex_begin_RELEASE;
     vertex_end = WebGL_vertex_end_RELEASE;
@@ -165,81 +165,274 @@ function WebGL_vertex_create_buffer_from_buffer(_buffer, _format)
     return WebGL_vertex_create_buffer_from_buffer_ext(_buffer, _format, 0, -1);
 }
 
-// #############################################################################################
-/// Function:<summary>
-///             Updates a vertex buffer from a portion of a regular buffer
-///          </summary>
-/// In:		<param name="_buffer"></param>
-///         <param name="_src_buffer"></param>
-///         <param name="_format"></param>
-///         <param name="_offset"></param>
-///         <param name="_num_vertices"></param>
-/// Out:	<returns>
-///				N/A 
-///			</returns>
-// #############################################################################################
-function WebGL_vertex_update_buffer_from_buffer_ext(_buffer, _src_buffer, _format, _offset, _num_vertices)
+function GetVertexElementFromOffset(pVBuffer, destOffset, destVert)
 {
-    _buffer = yyGetInt32(_buffer);
-    _format = yyGetInt32(_format);
-    _offset = yyGetInt32(_offset);
-    _num_vertices = yyGetInt32(_num_vertices);
+    var pFormat = pVBuffer.GetFormat();
+    if (!pFormat)
+    {
+        return false;
+    }
 
-    var total = 0;
+    var vert = ~~(destOffset / pFormat.ByteSize);
+    var destOffsetFromVert = destOffset - (vert * pFormat.ByteSize);
 
-    // get actual vertex format and buffer
-    var VertexFormat = g_webGL.GetVertexFormat(_format);
-    var pBuff = g_BufferStorage.Get(yyGetInt32(_src_buffer));
-    if (!pBuff || !VertexFormat) return;
-    
-
-    // if no vertex count passed in, then use the whole buffer - ignoring src offset as well
-    if (_num_vertices == -1) {
-        _offset = 0;
-        total = pBuff.m_UsedSize;
-        _num_vertices = total / VertexFormat.ByteSize;
-    } else {
-        total = _num_vertices * VertexFormat.ByteSize;
-        if ((total + _offset) > pBuff.m_UsedSize) {         // past end of buffer?
-            total = (pBuff.m_UsedSize - _offset);
-            _num_vertices = ~~(total / VertexFormat.ByteSize);      // round to nearest vertex
-            total = _num_vertices * VertexFormat.ByteSize;
+    for (var i = 0; i < pFormat.Format.length; ++i)
+    {
+        var element = pFormat.Format[i];
+        var elementTypeSize = pFormat.GetTypeSize(element.type);
+        if (destOffsetFromVert >= element.offset
+            && destOffsetFromVert < element.offset + elementTypeSize)
+        {
+            var elementSize = pFormat.GetElementSizeInType(element.type);
+            var destOffsetFromVertElem = destOffsetFromVert - element.offset;
+            if (destOffsetFromVertElem % elementSize == 0)
+            {
+                if (destVert !== undefined)
+                {
+                    destVert.vert = vert;
+                    destVert.elem = i;
+                    destVert.elemSub = ~~(destOffsetFromVertElem / elementSize);
+                }
+                return true;
+            }
         }
     }
 
-
-    // Create the new buffer and get it's class
-    var pVBuffer = g_vertexBuffers[_buffer];
-    pVBuffer.Resize(total);
-
-    // Now get the underlying arrays
-    var srcbytebuff = new Uint8Array(pBuff.m_pRAWUnderlyingBuffer);     // src
-    var dstbytebuff = new Uint8Array(pVBuffer.GetArrayBuffer());                 // dest
-
-    // And do the actual copy
-    pVBuffer.Begin(_format);
-    var src = _offset;
-    for (var i = 0; i < total; i++) {
-        dstbytebuff[i] = srcbytebuff[src++];
-    }
-    pVBuffer.SetVertexCount(_num_vertices);
-    pVBuffer.End();
+    return false;
 }
 
 // #############################################################################################
 /// Function:<summary>
-///             Updates a vertex buffer from a regular buffer
+///             Updates a vertex buffer with data from a regular buffer.
 ///          </summary>
-/// In:		<param name="_buffer"></param>
+/// In:		<param name="_dest_vbuff"></param>
+///         <param name="_dest_offset"></param>
 ///         <param name="_src_buffer"></param>
-///         <param name="_format"></param>
+///         <param name="_src_offset"></param>
+///         <param name="_src_size"></param>
 /// Out:	<returns>
-///				N/A
+///				N/A 
 ///			</returns>
 // #############################################################################################
-function WebGL_vertex_update_buffer_from_buffer(_buffer, _src_buffer, _format)
+function WebGL_vertex_update_buffer_from_buffer(_dest_vbuff, _dest_offset, _src_buffer, _src_offset, _src_size)
 {
-    return WebGL_vertex_update_buffer_from_buffer_ext(_buffer, _src_buffer, _format, 0, -1);
+    if (arguments.length < 3 || arguments > 5)
+    {
+        yyError("vertex_update_buffer_from_buffer: Illegal argument count");
+        return;
+    }
+
+    _dest_vbuff = yyGetInt32(_dest_vbuff);
+    _dest_offset = yyGetInt32(_dest_offset);
+    _src_buffer = yyGetInt32(_src_buffer);
+    _src_offset = (_src_offset !== undefined) ? yyGetInt32(_src_off) : 0;
+    _src_size = (_src_size !== undefined) ? yyGetInt32(_src_size) : -1;
+
+    var pVBuffer = g_vertexBuffers[_dest_vbuff];
+    if (!pVBuffer)
+    {
+        yyError("vertex_update_buffer_from_buffer: Vertex Buffer index is out of range");
+        return;
+    }
+
+    if (_dest_offset < 0)
+    {
+        yyError("vertex_update_buffer_from_buffer: destination offset must be a positive number");
+        return;
+    }
+
+    var pBuff = g_BufferStorage.Get(_src_buffer);
+    if (!pBuff)
+    {
+        yyError("vertex_update_buffer_from_buffer: specified buffer doesn't exists");
+        return;
+    }
+
+    if (_src_offset < 0)
+    {
+        yyError("vertex_update_buffer_from_buffer: source offset must be a positive number");
+        return;
+    }
+
+    if (pVBuffer.m_frozen)
+    {
+        yyError("vertex_update_buffer_from_buffer: cannot update a frozen vertex buffer");
+        return;
+    }
+
+    var pFormat = pVBuffer.GetFormat();
+    if (!pFormat)
+    {
+        yyError("vertex_update_buffer_from_buffer: unknown vertex buffer format");
+        return;
+    }
+
+    if (_src_size < 0)
+    {
+        _src_size = pBuff.m_UsedSize;
+    }
+
+    if (_src_size == 0)
+    {
+        // Nothing to copy...
+        return;
+    }
+
+    var destSize = _dest_offset + _src_size;
+
+    if (!GetVertexElementFromOffset(pVBuffer, _dest_offset))
+    {
+        yyError("vertex_update_buffer_from_buffer: destination offset must be aligned to a vertex element");
+        return;
+    }
+
+    if (!GetVertexElementFromOffset(pVBuffer, destSize))
+    {
+        yyError("vertex_update_buffer_from_buffer: destination size must be aligned to a vertex element");
+        return;
+    }
+
+    if (pVBuffer.m_UsedSize < destSize)
+    {
+        pVBuffer.Resize(destSize);
+    }
+
+    var srcByteArray = new Uint8Array(pBuff.m_pRAWUnderlyingBuffer);
+    var destByteArray = new Uint8Array(pVBuffer.GetArrayBuffer());
+    var src = _src_offset;
+    var dest = _dest_offset;
+    for (var i = 0; i < _src_size; i++)
+    {
+        destByteArray[dest++] = srcByteArray[src++];
+    }
+
+    pVBuffer.SetVertexCount(Math.max(pVBuffer.GetVertexCount(), ~~(destSize / pFormat.ByteSize)));
+}
+
+// #############################################################################################
+/// Function:<summary>
+///             Updates a vertex buffer with data from another vertex buffer.
+///          </summary>
+/// In:		<param name="_dest_vbuff"></param>
+///         <param name="_dest_offset"></param>
+///         <param name="_src_vbuff"></param>
+///         <param name="_src_vert"></param>
+///         <param name="_src_vert_num"></param>
+/// Out:	<returns>
+///				N/A 
+///			</returns>
+// #############################################################################################
+function WebGL_vertex_update_buffer_from_vertex(_dest_vbuff, _dest_vert, _src_vbuff, _src_vert, _src_vert_num)
+{
+    if (arguments.length < 3 || arguments > 5)
+    {
+        yyError("vertex_update_buffer_from_vertex: Illegal argument count");
+        return;
+    }
+
+    _dest_vbuff = yyGetInt32(_dest_vbuff);
+    _dest_vert = yyGetInt32(_dest_vert);
+    _src_vbuff = yyGetInt32(_src_vbuff);
+    _src_vert = (_src_vert !== undefined) ? yyGetInt32(_src_vert) : 0;
+    _src_vert_num = (_src_vert_num !== undefined) ? yyGetInt32(_src_vert_num) : -1;
+
+    var pDestBuffer = g_vertexBuffers[_dest_vbuff];
+    if (!pDestBuffer)
+    {
+        yyError("vertex_update_buffer_from_vertex: destination vertex buffer index is out of range");
+        return;
+    }
+
+    if (_dest_vert < 0)
+    {
+        yyError("vertex_update_buffer_from_vertex: destination vertex must be a positive number");
+        return;
+    }
+
+    var pSrcBuffer = g_vertexBuffers[_src_vbuff];
+    if (!pSrcBuffer)
+    {
+        yyError("vertex_update_buffer_from_vertex: source vertex buffer index is out of range");
+        return;
+    }
+
+    if (pDestBuffer == pSrcBuffer)
+    {
+        yyError("vertex_update_buffer_from_vertex: source and destination cannot be the same vertex buffer");
+        return;
+    }
+
+    if (pDestBuffer.m_frozen)
+    {
+        yyError("vertex_update_buffer_from_vertex: destination vertex buffer cannot be frozen");
+        return;
+    }
+
+    if (pSrcBuffer.m_frozen)
+    {
+        yyError("vertex_update_buffer_from_vertex: source vertex buffer cannot be frozen");
+        return;
+    }
+
+    var pSrcFormat = pSrcBuffer.GetFormat();
+    if (!pSrcFormat)
+    {
+        yyError("vertex_update_buffer_from_vertex: unknown source vertex buffer format");
+        return;
+    }
+
+    var pDestFormat = pDestBuffer.GetFormat();
+    if (!pDestFormat)
+    {
+        pDestFormat = pSrcFormat;
+        pDestBuffer.SetFVF(pSrcBuffer.GetFVF());
+    }
+    else if (!pDestFormat.Equals(pSrcFormat))
+    {
+        yyError("vertex_update_buffer_from_vertex: source and destination vertex buffers must use the same vertex format");
+        return;
+    }
+
+    if (_src_vert < 0)
+    {
+        yyError("vertex_update_buffer_from_vertex: source vertex must be a positive number");
+        return;
+    }
+
+    var formatSize = pDestFormat.ByteSize;
+    var srcOffset = _src_vert * formatSize;
+    var srcSize = _src_vert_num;
+    if (srcSize < 0)
+    {
+        srcSize = pBuff.GetVertexCount();
+    }
+    srcSize *= formatSize;
+    srcSize = Math.min(srcSize, (pSrcBuffer.GetVertexCount() * formatSize) - srcOffset);
+
+    if (srcSize == 0)
+    {
+        // Nothing to copy...
+        return;
+    }
+
+    var destOffset = _dest_vert * formatSize;
+    var destSize = destOffset + srcSize;
+
+    if (pSrcBuffer.m_UsedSize < destSize)
+    {
+        pSrcBuffer.Resize(destSize);
+    }
+
+    var srcByteArray = new Uint8Array(pSrcBuffer.GetArrayBuffer());
+    var destByteArray = new Uint8Array(pDestBuffer.GetArrayBuffer());
+    var src = srcOffset;
+    var dest = destOffset;
+    for (var i = 0; i < srcSize; i++)
+    {
+        destByteArray[dest++] = srcByteArray[src++];
+    }
+
+    pDestBuffer.SetVertexCount(Math.max(pDestBuffer.GetVertexCount(), ~~(destSize / formatSize)));
 }
 
 // #############################################################################################

--- a/scripts/yyBufferVertex.js
+++ b/scripts/yyBufferVertex.js
@@ -225,7 +225,7 @@ function WebGL_vertex_update_buffer_from_buffer(_dest_vbuff, _dest_offset, _src_
     _dest_vbuff = yyGetInt32(_dest_vbuff);
     _dest_offset = yyGetInt32(_dest_offset);
     _src_buffer = yyGetInt32(_src_buffer);
-    _src_offset = (_src_offset !== undefined) ? yyGetInt32(_src_off) : 0;
+    _src_offset = (_src_offset !== undefined) ? yyGetInt32(_src_offset) : 0;
     _src_size = (_src_size !== undefined) ? yyGetInt32(_src_size) : -1;
 
     var pVBuffer = g_vertexBuffers[_dest_vbuff];
@@ -271,6 +271,7 @@ function WebGL_vertex_update_buffer_from_buffer(_dest_vbuff, _dest_offset, _src_
     {
         _src_size = pBuff.m_UsedSize;
     }
+    _src_size = Math.min(_src_size, pBuff.m_UsedSize - _src_offset);
 
     if (_src_size == 0)
     {

--- a/scripts/yyVertexManager.js
+++ b/scripts/yyVertexManager.js
@@ -21,6 +21,7 @@ function vertex_format_add_normal()                         { ErrorFunction("ver
 function vertex_format_add_texcoord()                       { ErrorFunction("vertex_format_add_texcoord"); }
 function vertex_format_add_textcoord()                      { ErrorFunction("vertex_format_add_textcoord"); }
 function vertex_format_add_custom(type, usage)              { ErrorFunction("vertex_format_add_custom"); }
+function vertex_format_get_info(format_id)                  { ErrorFunction("vertex_format_get_info"); }
 
 // ---------------------------------------------------------------------------------------------
 // Tracks the format currently under construction
@@ -45,6 +46,7 @@ function InitFVFFunctions() {
     vertex_format_add_texcoord = WebGL_vertex_format_add_texcoord_RELEASE;
     vertex_format_add_textcoord = WebGL_vertex_format_add_texcoord_RELEASE; //This was in wrongly, add both spellings...
     vertex_format_add_custom = WebGL_vertex_format_add_custom_RELEASE;
+    vertex_format_get_info = WebGL_vertex_format_get_info_RELEASE;
 }
 
 // #############################################################################################
@@ -173,4 +175,34 @@ function WebGL_vertex_format_delete_RELEASE(_format_id)
 {
     // BM: Stubbed as the underlying system shares vertex formats but DOESN'T reference count.
     debug("WARNING vertex_format_delete not implemented on HTML5 (System shares vertex formats but doesn't reference count)");
+}
+
+function WebGL_vertex_format_get_info_RELEASE(_format_id)
+{
+    var format = g_webGL.GetVertexFormat(yyGetInt32(_format_id));
+
+    if (!format)
+        return undefined;
+
+    pVFI = new GMLObject();
+
+    variable_struct_set(pVFI, "stride", format.ByteSize);
+    variable_struct_set(pVFI, "num_elements", format.Format.length);
+
+    var elementsArray = [];
+    for (var i = 0; i < format.Format.length; ++i)
+    {
+        var element = format.Format[i];
+        var pElementI = new GMLObject();
+
+        variable_struct_set(pElementI, "usage", element.usage);
+        variable_struct_set(pElementI, "type", element.type);
+        variable_struct_set(pElementI, "size", format.GetTypeSize(element.type));
+        variable_struct_set(pElementI, "offset", element.offset);
+
+        elementsArray.push(pElementI);
+    }
+    variable_struct_set(pVFI, "elements", elementsArray);
+
+    return pVFI;
 }


### PR DESCRIPTION
Added functions

* `vertex_update_buffer_from_buffer(dest_vbuff,dest_offset,src_buffer,[src_offset],[src_size])`
* `vertex_update_buffer_from_vertex(dest_vbuff,dest_vert,src_vbuff,[src_vert],[src_vert_num])`

which can be used to update contents of a vertex buffer from another vertex buffer or a regular buffer. Updating frozen vertex buffers is not yet supported.

Additionally function `vertex_format_get_info(format_id)` was added for easier manipulation with the data. This function returns a struct containing:

* `stride` - the size of a single vertex in bytes
* `num_elements` - number of elements that a single vertex consists of
* `elements` - an array of elements, where each element is a struct containing:
    * `usage` - the usage (position, normal, etc.)
    * `type` -  the element type (float1, float2, etc.)
    * `size` - the size of the element in bytes
    * `offset` - the offset from the vertex (in bytes)