### PR TITLE
Issue 307: Fixed return value for vertex_freeze()

### DIFF
--- a/scripts/Builders/yyVBufferBuilder.js
+++ b/scripts/Builders/yyVBufferBuilder.js
@@ -414,7 +414,10 @@ function yyVBufferBuilder(_size) {
         return m_arrayBuffer;
     };
 
-
+    this.IsFrozen = function ()
+    {
+        return m_frozen;
+    };
 }
 
 

--- a/scripts/yyBufferVertex.js
+++ b/scripts/yyBufferVertex.js
@@ -628,9 +628,11 @@ function WebGL_vertex_ubyte4_RELEASE(_buffer, x, y, z, w) {
 function WebGL_vertex_freeze_RELEASE(_buffer) {
 
     var vertexBuffer = g_vertexBuffers[yyGetInt32(_buffer)];
-    if (vertexBuffer) {    
-        vertexBuffer.Freeze();          
+    if (vertexBuffer && !vertexBuffer.IsFrozen()) {
+        vertexBuffer.Freeze();
+        return 0;
     }
+    return -1;
 }
 
 // #############################################################################################


### PR DESCRIPTION
Function `vertex_freeze()` returned undefined instead of 0 on success and -1 on fail.

Closes https://github.com/YoYoGames/GameMaker-HTML5/issues/307
