### PR TITLE
Issue-334: part_type_sprite causes exception - uncaught ReferenceError

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -44,7 +44,7 @@ function GetParticleTypeIndex(_arg, _optional)
 
 function GetSpriteIndex(_arg)
 {
-    var index = yyGetInt32(_spriteIndex);
+    var index = yyGetInt32(_arg);
     if (g_pSpriteManager.Get(index) == null)
         yyError("invalid reference to sprite");
     return index;


### PR DESCRIPTION
Fixed wrong variable name. Closes https://github.com/YoYoGames/GameMaker-HTML5/issues/334.
