### PR TITLE
GM-6825: [LTS] Constrain gain, pitch and offset prop values 

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -620,9 +620,13 @@ class AudioPlaybackProps
         this.priority = yyGetReal(_priority);
         this.loop = yyGetReal(_loop);
 
-        this.gain = _gain;
+        this.gain = Math.max(0, _gain);
+        this.pitch = Math.max(0, _pitch);
         this.offset = _offset;
-        this.pitch = _pitch;
+
+        if (this.offset !== AudioPropsCalc.not_specified) {
+            this.offset = Math.max(0, this.offset);
+        }
     }
 
     Invalid()


### PR DESCRIPTION
Brings a fix over to master-LTS-22 for LTS r2:
- Adapts https://github.com/YoYoGames/GameMaker-HTML5/commit/28d0376cd1e75897264ff27d9d8597229900667d , which was a fix for [GM-6825](https://bugs.opera.com/browse/GM-6825).

Original PR: https://github.com/YoYoGames/GameMaker-HTML5/pull/164