### PR TITLE
Issue-334: part_type_sprite causes exception - uncaught ReferenceError 

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -44,7 +44,7 @@ function GetParticleTypeIndex(_arg, _optional)
 
 function GetSpriteIndex(_arg)
 {
-    var index = yyGetInt32(_spriteIndex);
+    var index = yyGetInt32(_arg);
     if (g_pSpriteManager.Get(index) == null)
         yyError("invalid reference to sprite");
     return index;


### PR DESCRIPTION
Bringing https://github.com/YoYoGames/GameMaker-HTML5/pull/337 into Aug, where it was supposed to go instead of develop.
