### PR TITLE
Issue 1688: Functions effect_create_above/below don't work the first time used

### DIFF
--- a/scripts/functions/Function_Particles.js
+++ b/scripts/functions/Function_Particles.js
@@ -1447,7 +1447,9 @@ function part_emitter_relative(_ps, _ind, _enable)
 // #############################################################################################
 function effect_create_below(_kind, _x, _y, _size, _color)
 {
-	Effect_Create(ps_below, yyGetInt32(_kind), yyGetReal(_x), yyGetReal(_y), yyGetInt32(_size), yyGetInt32(_color));
+    if (ps_below == -1)
+        Eff_Check_Systems();
+    Effect_Create(ps_below, yyGetInt32(_kind), yyGetReal(_x), yyGetReal(_y), yyGetInt32(_size), yyGetInt32(_color));
 }
 
 // #############################################################################################
@@ -1467,7 +1469,9 @@ function effect_create_below(_kind, _x, _y, _size, _color)
 // #############################################################################################
 function effect_create_above(_kind, _x, _y, _size, _color)
 {
-	Effect_Create(ps_above, yyGetInt32(_kind), yyGetReal(_x), yyGetReal(_y), yyGetInt32(_size), yyGetInt32(_color));
+    if (ps_above == -1)
+        Eff_Check_Systems();
+    Effect_Create(ps_above, yyGetInt32(_kind), yyGetReal(_x), yyGetReal(_y), yyGetInt32(_size), yyGetInt32(_color));
 }
 
 // #############################################################################################

--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -1999,7 +1999,7 @@ function ParticleSystem_Particles_Create(_ps, _x, _y, _parttype, _numb)
 
 	if (em == -1)
 	{
-		em = ParticleSystem_Emitter_Create(ps);
+		em = ParticleSystem_Emitter_Create(_ps);
 	}
 
 	EmitParticles(system, system.emitters[em], _x, _y, _parttype, _numb);
@@ -2045,7 +2045,7 @@ function	ParticleSystem_Particles_Create_Color( _ps, _x, _y, _parttype, _col, _n
 
 	if (em == -1)
 	{
-		em = ParticleSystem_Emitter_Create(ps);
+		em = ParticleSystem_Emitter_Create(_ps);
 	}
 
 	EmitParticles(system, system.emitters[em], _x, _y, _parttype, _numb, true, _col);


### PR DESCRIPTION
This happened because the function used yet uninitialized particle systems `ps_above` and `ps_below`.  

Issue link: https://github.com/YoYoGames/GameMaker-Bugs/issues/1688

Additionally bringing in fix from https://github.com/YoYoGames/GameMaker-HTML5/pull/336.
