### PR TITLE
GM-2953: Fix buffer used size in buffer_copy_stride

### DIFF
--- a/scripts/yyBuffer.js
+++ b/scripts/yyBuffer.js
@@ -2249,6 +2249,7 @@ function buffer_copy_stride(_src_buffer, _src_offset, _src_size, _src_stride, _s
 			}
 
 			destBytes[indexTo] = srcBytes[indexFrom];
+            destBuffer.m_UsedSize = Math.max(destBuffer.m_UsedSize, indexTo + 1);
 		}
 
 		_src_offset += _src_stride;


### PR DESCRIPTION
Function `buffer_copy_stride` did not update `m_UsedSize` property of the destination buffer.

Issue link: https://github.com/YoYoGames/GameMaker/issues/2953

