### PR TITLE
fixed variable naming causing crash

### DIFF
--- a/scripts/sound/worklets/Reverb1Processor.js
+++ b/scripts/sound/worklets/Reverb1Processor.js
@@ -178,10 +178,10 @@ class Reverb1Processor extends AudioWorkletProcessor
             const inputChannel = input[c];
             const outputChannel = output[c];
 
-            for (let s = 0; s < inputChannel.length; ++s) {
+            for (let i = 0; i < inputChannel.length; ++i) {
                 const s = (size[s] !== undefined) ? size[s] : size[0];
                 const d = (damp[s] !== undefined) ? damp[s] : damp[0];
-
+                
                 // Update model if needed
                 this.setSize(s);
                 this.setDamp(d);


### PR DESCRIPTION
![image](https://github.com/YoYoGames/GameMaker-HTML5/assets/24947167/2d69fb66-61bd-4bf6-8471-27ef5d35ef32)

