### PR TITLE
PR: fix for HTML5 crash when particle type destroyed but emitter is still alive

### DIFF
--- a/scripts/yyParticle.js
+++ b/scripts/yyParticle.js
@@ -2680,6 +2680,9 @@ function HandleLife( _ps, _em )
 		var pParticle = pParticles[i];
 		var pParType = g_ParticleTypes[ pParticle.parttype ];
 
+		// Fix for null particle HTML5 crash - happens when particle type is destroyed but emitter is still alive
+		if (pParType === null) return;
+		
 		// Update the age and create death particles
 		pParticle.age++;
 			
@@ -2741,7 +2744,10 @@ function HandleMotion( _ps, _em )
 	{
 		var pParticle = pParticles[i];
 		var pParType = g_ParticleTypes[ pParticle.parttype ];
-	
+		
+		// Fix for null particle HTML5 crash - happens when particle type is destroyed but emitter is still alive
+		if (pParType === null) continue;
+		
 		// adapt speed and direction and angle
 		pParticle.speed = pParticle.speed + pParType.spincr;
 		if ( pParticle.speed < 0 ) pParticle.speed = 0;
@@ -2809,6 +2815,8 @@ function  HandleShape(_ps, _em)
 		var pParticle = pParticles[i];
 		var pParType = g_ParticleTypes[ pParticle.parttype ];
 		
+		// Fix for null particle HTML5 crash - happens when particle type is destroyed but emitter is still alive
+		if (pParType === null) continue;
 		
 		// adapt the size
 		pParticle.xsize = pParticle.xsize + pParType.sizeIncrX;
@@ -2963,7 +2971,9 @@ function	DrawParticle(_pPartSys, _pParticle, _xoff, _yoff, _color, _alpha)
 
 	if ( _pParticle.lifetime <= 0 ) return;
 	var pParType = g_ParticleTypes[ _pParticle.parttype ];
-
+	
+	// Fix for null particle HTML5 crash - happens when particle type is destroyed but emitter is still alive
+	if (pParType === null) return;
 
 	spr = g_pSpriteManager.Get( pParType.sprite );
 	if( spr == null )


### PR DESCRIPTION
The HTML5 runner handles this situation differently than the rest of the runners (Windows, OperaGX, etc.). If we emitted particles and then we destroy the particle type, and we also destroy the emitter, there's no problem. However, if we just destroy the type and do not destroy the emitter (for example because we are reusing a previously existing emitter), the game will crash.

The fix is very simple: it checks if `pParType === null` in the following functions of the `yyParticle.js` file:

- DrawParticle
- HandleLife
- HandleMotion
- HandleShape

If so, it exits the function / continues to the next iteration.

**Replicating the issue and confirming the fix**

The behavior can be checked with the included sample project. 
[Particle Problem HTML5.zip](https://github.com/YoYoGames/GameMaker-HTML5/files/12865490/Particle.Problem.HTML5.zip)

- Move the mouse around to see particles being emitted
- Press left click to destroy the `obj_Test` object that has the particle type defined and destroys it on Cleanup.
- The emitter and system are defined in a separate `Game` controller object and are destroyed on that controller's Cleanup event (i.e, game end)
- There is an animated sprite that is just there to confirm the game is still running

- Try it on Windows / OperaGX to see no crash occurs
- Try it on HTML5 to confirm crash occurs
- Try it with the runner including the pull request (modified `yyParticle.js`) to confirm the problem is gone.


manta ray