### PR TITLE
Fix https://github.com/YoYoGames/GameMaker-Bugs/issues/1667 

### DIFF
--- a/scripts/functions/Function_YoYo.js
+++ b/scripts/functions/Function_YoYo.js
@@ -1337,6 +1337,7 @@ function script_execute( _self, _other, _index )
 var method_call = script_execute_ext;
 function script_execute_ext( _self, _other, _index, _array, _offset, _length )
 {
+	_array = _array || [];
     _offset = _offset || 0;
     _offset = yyGetInt32(_offset);
     _length = _length || _array.length - _offset;


### PR DESCRIPTION
* script_execute_ext array parameter is now optional