### PR TITLE
GMB-1774: Show error in `vertex_submit` when texture does not exist

### DIFF
--- a/scripts/Builders/yyVBufferBuilder.js
+++ b/scripts/Builders/yyVBufferBuilder.js
@@ -355,7 +355,7 @@ function yyVBufferBuilder(_size) {
     ///          </summary>
     // #############################################################################################
     /** @this {yyVBufferBuilder} */	
-    this.Submit = function(_primType, _texture) {;
+    this.Submit = function(_primType, _texture) {
         if (m_frozen) {
 
             // Directly submit the vertex buffer

--- a/scripts/Builders/yyVBufferBuilder.js
+++ b/scripts/Builders/yyVBufferBuilder.js
@@ -355,8 +355,7 @@ function yyVBufferBuilder(_size) {
     ///          </summary>
     // #############################################################################################
     /** @this {yyVBufferBuilder} */	
-    this.Submit = function(_primType, _texture) {
-
+    this.Submit = function(_primType, _texture) {;
         if (m_frozen) {
 
             // Directly submit the vertex buffer
@@ -369,6 +368,10 @@ function yyVBufferBuilder(_size) {
                 // Check whether the webgl texture has been initialised yet and do so if not
                 if (_texture && !_texture.WebGLTexture.webgl_textureid) {
                     WebGL_BindTexture(_texture.TPE);
+                    if (!WebGL_IsTextureValid(_texture.WebGLTexture.webgl_textureid, WebGL_gpu_get_tex_mip_enable())) {
+                        yyError("vertex_submit: trying to use a texture that does not exist");
+                        return;
+                    }
                 }
                 g_webGL.DispatchVBuffer(_primType, _texture.WebGLTexture.webgl_textureid, m_VBuffer, 0);
             }
@@ -381,6 +384,10 @@ function yyVBufferBuilder(_size) {
                 // Check whether the webgl texture has been initialised yet and do so if not
                 if (_texture && !_texture.WebGLTexture.webgl_textureid) {
                     WebGL_BindTexture(_texture.TPE);
+                    if (!WebGL_IsTextureValid(_texture.WebGLTexture.webgl_textureid, WebGL_gpu_get_tex_mip_enable())) {
+                        yyError("vertex_submit: trying to use a texture that does not exist");
+                        return;
+                    }
                 }
                 pBuff = g_webGL.AllocVerts(_primType, _texture.WebGLTexture.webgl_textureid, m_FVF, m_vertexCount);
             }


### PR DESCRIPTION
Previously this would cause a crash when doing:

```gml
surface = surface_create(...);
texture = surface_get_texture(surface);
surface_free(surface);
vertex_submit(..., texture);
```

Now it shows an error that the texture does not exist.

Issue link: https://github.com/YoYoGames/GameMaker-Bugs/issues/1774
