### PR TITLE
Compress tilemaps with Run Length Encoding (RLE)

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -2000,15 +2000,15 @@ LayerManager.prototype.BuildRoomLayers = function(_room,_roomLayers)
                     TileLayer.m_backgroundIndex = pLayer.tIndex;
                     TileLayer.m_mapWidth = pLayer.tMapWidth;
                     TileLayer.m_mapHeight = pLayer.tMapHeight;
-                    TileLayer.m_pTiles=[];
+                    TileLayer.m_pTiles=expandTiles(pLayer.ttiles);
 
                     var numtiles =0;
                     if(pLayer.tcount!=undefined) numtiles =pLayer.tcount; 
                     
-                    for(var i=0;i<numtiles;i++)
-                    {
-                    TileLayer.m_pTiles[i]= pLayer.ttiles[i];
-                    }
+                    //for(var i=0;i<numtiles;i++)
+                    //{
+                    //TileLayer.m_pTiles[i]= pLayer.ttiles[i];
+                    //}
                     if(pLayer.pName!=undefined) TileLayer.m_name = pLayer.pName;
             
                     this.AddNewElement(_room,NewLayer,TileLayer,false);

--- a/scripts/functions/Function_Room.js
+++ b/scripts/functions/Function_Room.js
@@ -185,7 +185,7 @@ function room_get_info(_ind, _views, _instances, _layers, _layer_elements, _tile
                         variable_struct_set(param, "type", sourceLayer.effectProperties[effectPropIdx].type);
                         variable_struct_set(param, "name", sourceLayer.effectProperties[effectPropIdx].name);
                         variable_struct_set(param, "value", sourceLayer.effectProperties[effectPropIdx].value);
-                        newLayer.effectParams[effectPropIdx] = param;
+                        effectParams[effectPropIdx] = param;
                     }
                     variable_struct_set(newLayer, "effectParams", effectParams);
                     // @endif
@@ -237,7 +237,7 @@ function room_get_info(_ind, _views, _instances, _layers, _layer_elements, _tile
                                 variable_struct_set( element, "height", sourceLayer.tMapHeight ? sourceLayer.tMapHeight : 0 );
                                 variable_struct_set( element, "background_index", sourceLayer.tIndex ? sourceLayer.tIndex : 0 );
                                 if (_tilemap_data)
-                                    variable_struct_set( element, "tiles", sourceLayer.ttiles ? sourceLayer.ttiles.slice( 0 ) : [] );
+                                    variable_struct_set( element, "tiles", sourceLayer.ttiles ? expandTiles(sourceLayer.ttiles) : [] );
                                 break;
 
                             case YYLayerType_Asset:

--- a/scripts/yyRoom.js
+++ b/scripts/yyRoom.js
@@ -157,8 +157,8 @@ function expandTiles( stiles )
 	var r = [];
 	for( var i=0; i<stiles.length;) {
 		var c = stiles[i++];
-		if (c & 0x80) {
-			var b = c & 0x7f;
+		if (c & 0x80000000) {
+			var b = c & 0x7fffffff;
 			++b;
 			var v = stiles[i++];
 			for( var cc=0; cc<b; ++cc) {
@@ -166,7 +166,7 @@ function expandTiles( stiles )
 			} // end for
 		} // end if 
 		else {
-			var b = c & 0x7f;
+			var b = c & 0x7fffffff;
 			for( var cc=0; cc<b; ++cc) {
 				r.push( stiles[i++] );
 			} // end for

--- a/scripts/yyRoom.js
+++ b/scripts/yyRoom.js
@@ -151,6 +151,30 @@ yyRoom.prototype.CreateEmptyStorage = function () {
 
 };
 
+// return an expanded array of the tiles, stiles is an array with the tiles RLE compressed 
+function expandTiles( stiles )
+{
+	var r = [];
+	for( var i=0; i<stiles.length;) {
+		var c = stiles[i++];
+		if (c & 0x80) {
+			var b = c & 0x7f;
+			++b;
+			var v = stiles[i++];
+			for( var cc=0; cc<b; ++cc) {
+				r.push( v );
+			} // end for
+		} // end if 
+		else {
+			var b = c & 0x7f;
+			for( var cc=0; cc<b; ++cc) {
+				r.push( stiles[i++] );
+			} // end for
+		} // end else
+	} // end for
+	return r;
+}
+
 
 // #############################################################################################
 /// Function:<summary>


### PR DESCRIPTION
* All tilemaps are now compressed with RLE
* JS scheme is slightly different to C++ scheme
* <control-count>, values*
* where control-count is a number if top bit is set 0x80000000 then it is a RUN and copy the next value count+1 number of times (remove the top bit). if not then copy the next count values