### PR TITLE
Improve tracking of Spine animation wrapping.

### DIFF
--- a/scripts/animation/yySkeletonInstance.js
+++ b/scripts/animation/yySkeletonInstance.js
@@ -728,8 +728,8 @@ yySkeletonInstance.prototype.SetAnimationTransform = function (_ind, _x, _y, _sc
 	    var frameCount = this.FrameCount(_spr, 0);
 	    if (frameCount > 0)
 	    {
-	        var frameCurr = _ind % frameCount,
-			    frameLast = this.m_lastFrame % frameCount,
+	        var frameCurr = _ind,
+			    frameLast = this.m_lastFrame,
 			    duration = this.m_animation.duration,
 			    timelineCount = this.m_animation.timelines.length;
 			    
@@ -747,6 +747,10 @@ yySkeletonInstance.prototype.SetAnimationTransform = function (_ind, _x, _y, _sc
 	        if ((this.m_lastFrameDir > 0) && (frameCurr < frameLast))
 	        {
 	            // Assume we're moving in the same direction as last frame when handling wrapping behaviour
+	            // NOTE: This should only be hit when people are setting image_index manually - when it is
+	            // being advanced automatically we should receive an over/under-flowed _ind for one frame
+	            // so we can handle wrapping without having to use this heuristic which can fail depending on
+	            // animation speed/length...
 	            frameCurr += frameCount;
 	        }
 	        /*else if ((m_lastFrameDir < 0) && (frameCurr > frameLast))
@@ -767,7 +771,7 @@ yySkeletonInstance.prototype.SetAnimationTransform = function (_ind, _x, _y, _sc
 
 	    this.m_animationState.apply(this.m_skeleton);
 
-	    this.m_lastFrame = _ind;		    
+	    this.m_lastFrame = _ind % frameCount;
 
 	    skeleton.x = _x;
 	    skeleton.y = _y;

--- a/scripts/functions/Function_Graphics.js
+++ b/scripts/functions/Function_Graphics.js
@@ -1786,6 +1786,7 @@ function skeleton_animation_set(_inst, _name, _loop = true) {
 	{		
 		skeletonAnim.SelectAnimation(yyGetString(_name), _loop);
 		_inst.image_index = 0;
+		_inst.frame_overflow = 0;
 		skeletonAnim.SetImageIndex(0, 0);
     }    
 }
@@ -1819,6 +1820,7 @@ function skeleton_animation_set_ext(_inst, _anim, _track, _loop = true) {
         if (_track == 0)
         {
             _inst.image_index = 0;
+            _inst.frame_overflow = 0;
             skeletonAnim.SetImageIndex(0, 0);
         }
 	}

--- a/scripts/functions/Function_Texture.js
+++ b/scripts/functions/Function_Texture.js
@@ -36,7 +36,10 @@ function draw_self( _inst )
     	var spr = g_pSpriteManager.Get(index);
     	if( spr != null ){
     	    //spr.Draw( Math.floor(_inst.image_index ),
-    	    spr.Draw(_inst.image_index,
+    	    var image_index = _inst.image_index + _inst.frame_overflow;
+    	    _inst.frame_overflow = 0;
+
+    	    spr.Draw(image_index,
 				_inst.x,_inst.y,_inst.image_xscale, _inst.image_yscale,
 				_inst.image_angle, _inst.image_blend, _inst.image_alpha);
     	}


### PR DESCRIPTION
The image_index instance variable is usually wrapped when it is advanced automatically, and setAnimationTransform() attempted to detect this through some heuristics, however with different combinations of animation length, speed and position it could incorrectly detect the animation wrapping with multiple outcomes, such as the animation jumping backwards/forwards or running at the wrong speed.

We now accumulate the "extra" frames when wrapping image_index and add them to the index passed into setAnimationTransform() for a single frame so setAnimationTransform() can accurately calculate the time delta and advance the animation forwards/backwards correctly.

The heuristics are still in-place in case of any projects explicitly setting the image_index on each frame but expecting the animation to advance smoothly.

https://github.com/YoYoGames/GameMaker-Bugs/issues/1895