### PR TITLE
Fixed #1509 -  Various sprite functions incorrectly do not error when index or subimage are called using the wrong type

### DIFF
--- a/scripts/functions/Function_Sprite.js
+++ b/scripts/functions/Function_Sprite.js
@@ -1446,7 +1446,11 @@ function sprite_set_cache_size_ext(_ind, _index, _max) {
 // #############################################################################################
 function sprite_get_tpe(_index, _subimage)
 {
-    _index = yyGetInt32(_index);
+    _index = yyGetInt32(yyGetRef(_index, REFID_SPRITE, g_pSpriteManager.Sprites.length, g_pSpriteManager.Sprites));
+	if(typeof _subimage != "number")
+	{
+		yyError("sprite_get_tpe() subimg argument should be a Real!");
+	}
     _subimage = yyGetInt32(_subimage);
 
 	var pSpr = g_pSpriteManager.Get(_index);
@@ -1492,8 +1496,12 @@ function sprite_get_tpe(_index, _subimage)
 // #############################################################################################
 function sprite_get_texture(_spriteIndex, _frameIndex)
 {
-    _spriteIndex = yyGetInt32(_spriteIndex);
-
+    _spriteIndex = yyGetInt32(yyGetRef(_spriteIndex, REFID_SPRITE, g_pSpriteManager.Sprites.length, g_pSpriteManager.Sprites));
+	if(typeof _frameIndex != "number")
+	{
+		yyError("sprite_get_texture() subimg argument should be a Real!");
+	}
+	
     if (sprite_exists(_spriteIndex)) {
     
         var spr = g_pSpriteManager.Get(_spriteIndex);        
@@ -1526,8 +1534,11 @@ function sprite_get_texture(_spriteIndex, _frameIndex)
 // #############################################################################################
 function sprite_get_uvs(_spriteIndex, _frameIndex)
 {
-    _spriteIndex = yyGetInt32(_spriteIndex);
-
+    _spriteIndex = yyGetInt32(yyGetRef(_spriteIndex, REFID_SPRITE, g_pSpriteManager.Sprites.length, g_pSpriteManager.Sprites));
+	if(typeof _frameIndex != "number")
+	{
+		yyError("sprite_get_uvs() subimg argument should be a Real!");
+	}
     if (sprite_exists(_spriteIndex)) {
     
         var spr = g_pSpriteManager.Get(_spriteIndex);

--- a/scripts/functions/Function_Sprite.js
+++ b/scripts/functions/Function_Sprite.js
@@ -1446,7 +1446,7 @@ function sprite_set_cache_size_ext(_ind, _index, _max) {
 // #############################################################################################
 function sprite_get_tpe(_index, _subimage)
 {
-    _index = yyGetInt32(yyGetRef(_index, REFID_SPRITE, g_pSpriteManager.Sprites.length, g_pSpriteManager.Sprites));
+    _index = yyGetRef(_index, REFID_SPRITE, g_pSpriteManager.Sprites.length, g_pSpriteManager.Sprites);
 	if(typeof _subimage != "number")
 	{
 		yyError("sprite_get_tpe() subimg argument should be a Real!");
@@ -1496,7 +1496,7 @@ function sprite_get_tpe(_index, _subimage)
 // #############################################################################################
 function sprite_get_texture(_spriteIndex, _frameIndex)
 {
-    _spriteIndex = yyGetInt32(yyGetRef(_spriteIndex, REFID_SPRITE, g_pSpriteManager.Sprites.length, g_pSpriteManager.Sprites));
+    _spriteIndex = yyGetRef(_spriteIndex, REFID_SPRITE, g_pSpriteManager.Sprites.length, g_pSpriteManager.Sprites);
 	if(typeof _frameIndex != "number")
 	{
 		yyError("sprite_get_texture() subimg argument should be a Real!");
@@ -1534,7 +1534,7 @@ function sprite_get_texture(_spriteIndex, _frameIndex)
 // #############################################################################################
 function sprite_get_uvs(_spriteIndex, _frameIndex)
 {
-    _spriteIndex = yyGetInt32(yyGetRef(_spriteIndex, REFID_SPRITE, g_pSpriteManager.Sprites.length, g_pSpriteManager.Sprites));
+    _spriteIndex = yyGetRef(_spriteIndex, REFID_SPRITE, g_pSpriteManager.Sprites.length, g_pSpriteManager.Sprites);
 	if(typeof _frameIndex != "number")
 	{
 		yyError("sprite_get_uvs() subimg argument should be a Real!");


### PR DESCRIPTION
HTML5 runner changes to fix issue 1509 - Various sprite functions incorrectly do not error when index or subimage are called using the wrong type