### PR TITLE
Return true from audio_is_playing for decoding streamed sounds

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -575,11 +575,12 @@ audioSound.prototype.isPlaying = function() {
         return true;
     }
     else {
+        // If the voice is active, but we have no buffer,
+        // then we are decoding and considered to be playing.
         if (this.pbuffersource === null)
-            return false;
+            return true;
 
         //NB- "playbackState" is only defined for webkitAudioContext - undefined for AudioContext
-        // ... we should get rid of it then
         if (this.pbuffersource.playbackState == undefined 
         || this.pbuffersource.playbackState != this.pbuffersource.FINISHED_STATE
         || this.paused) {


### PR DESCRIPTION
- Returns `true` from `audioSound.prototype.isPlaying` if the voice is active, but lacks a buffer. This indicates that the sound is still decoding, which we consider to be playing.
- Fixes https://github.com/YoYoGames/GameMaker-Bugs/issues/2556.