### PR TITLE
Add check for decoding sounds when resuming voices

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -558,6 +558,12 @@ audioSound.prototype.resume = function() {
     }
     else {
         this.startoffset = this.playbackCheckpoint.bufferTime;
+
+        // If we are still decoding then there's nothing to do with the buffer source
+        if (this.pbuffersource == null) {
+            return;
+        }
+        
         this.start(this.pbuffersource.buffer);
     }
 };

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -560,7 +560,7 @@ audioSound.prototype.resume = function() {
         this.startoffset = this.playbackCheckpoint.bufferTime;
 
         // If we are still decoding then there's nothing to do with the buffer source
-        if (this.pbuffersource == null) {
+        if (this.pbuffersource === null) {
             return;
         }
         


### PR DESCRIPTION
- Avoids acting on a voice's buffer in `audioSound.prototype.resume` if it is still decoding. The post-decoding callback will start the sound according to its state at that time, so any play state transitions while decoding are taken into account.
- Fixes https://github.com/YoYoGames/GameMaker-HTML5/issues/411.