### PR TITLE
Fixing video playback on Firefox. Using requestAnimationFrame as a fallback for when requestVideoFrameCallback is undefined

### DIFF
--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -97,6 +97,21 @@ window.yyRequestAnimationFrame =
     window.mozRequestAnimationFrame    || 
     window.oRequestAnimationFrame      || 
     window.msRequestAnimationFrame;
+	
+window.yyCancelAnimationFrame = 
+    window.cancelAnimationFrame       ||
+    window.webkitCancelAnimationFrame ||
+    window.mozCancelAnimationFrame    ||
+    window.oCancelAnimationFrame      ||
+    window.msCancelAnimationFrame;
+
+if (!window.yyCancelAnimationFrame) {
+    window.cancelAnimFrame = function(id) {
+        clearTimeout(id);
+    };
+} else {
+    window.cancelAnimFrame = window.yyCancelAnimationFrame;
+}
 
 if (!window.yyRequestAnimationFrame) {
     // if RAF is somehow amiss but we need short timeouts, register a message handler

--- a/scripts/yyVideo.js
+++ b/scripts/yyVideo.js
@@ -14,12 +14,6 @@
 var g_VideoUserEnded = false; //For some reason I can't figure this from the video player...
 var g_AnimationFrameRequestID = null;
 
-const requestAnimationFrame =
-  window.requestAnimationFrame ||
-  window.mozRequestAnimationFrame ||
-  window.webkitRequestAnimationFrame ||
-  window.msRequestAnimationFrame;
-
 function video_get_format() {
     var video_format_rgba = 0;
     var video_format_yuv = 1;
@@ -101,12 +95,13 @@ function video_open(path)
     
     if (myVideo.requestVideoFrameCallback === undefined) { //urgh can't use nice fast playback
         console.log("requestVideoFrameCallback not supported by browser, falling back to requestAnimationFrame");
-        let fpsInterval = 1000 / 30;
+        let fpsInterval = 1000 / 29.97;
         let then = Date.now();
-
+		
         function updateVideoFrame() {
             if (!g_VideoUserEnded) {
-                g_AnimationFrameRequestID = requestAnimationFrame(updateVideoFrame);
+				g_AnimationFrameRequestID = requestAnimationFrame(updateVideoFrame);
+				console.log(g_AnimationFrameRequestID);
                 let now = Date.now();
                 let elapsed = now - then;
 
@@ -121,7 +116,12 @@ function video_open(path)
                         gameCanvas.videoContext.drawImage(gameCanvas.yyvideoplayer, 0, 0);
                     }
                 }
-            }
+            }else{
+			if(g_AnimationFrameRequestID){
+			cancelAnimationFrame(g_AnimationFrameRequestID);
+			g_AnimationFrameRequestID = null;
+			}
+			}
         }
 		
         myVideo.addEventListener('timeupdate', function () {

--- a/scripts/yyVideo.js
+++ b/scripts/yyVideo.js
@@ -13,9 +13,6 @@
 // @if function("video_")
 var g_VideoUserEnded = false; //For some reason I can't figure this from the video player...
 var g_AnimationFrameRequestID = null;
-var g_AnimationFrameRequestID = null;
-
-var g_AnimationFrameRequestID = null;  
 
 const requestAnimationFrame =
   window.requestAnimationFrame ||

--- a/scripts/yyVideo.js
+++ b/scripts/yyVideo.js
@@ -13,6 +13,9 @@
 // @if function("video_")
 var g_VideoUserEnded = false; //For some reason I can't figure this from the video player...
 var g_AnimationFrameRequestID = null;
+var g_AnimationFrameRequestID = null;
+
+var g_AnimationFrameRequestID = null;  
 
 const requestAnimationFrame =
   window.requestAnimationFrame ||
@@ -104,21 +107,6 @@ function video_open(path)
         let fpsInterval = 1000 / 30;
         let then = Date.now();
 
-        myVideo.addEventListener('playing', function () {
-            playing = true;
-            console.log("Video playing event called");
-            checkReady();
-
-            var map = ds_map_create();
-
-            ds_map_add(map, "type", "video_start");
-
-            g_pBuiltIn.async_load = map;
-            g_pObjectManager.ThrowEvent(EVENT_OTHER_SOCIAL, 0);
-            ds_map_destroy(map);
-
-        }, true);
-
         function updateVideoFrame() {
             if (!g_VideoUserEnded) {
                 g_AnimationFrameRequestID = requestAnimationFrame(updateVideoFrame);
@@ -134,7 +122,6 @@ function video_open(path)
 
                     if ((gameCanvas.yyvideoplayer != null) && (gameCanvas.videoContext != null)) {
                         gameCanvas.videoContext.drawImage(gameCanvas.yyvideoplayer, 0, 0);
-                        requestAnimationFrame(updateVideoFrame);
                     }
                 }
             }
@@ -152,6 +139,13 @@ function video_open(path)
         console.log("Video playing event called");
         checkReady();
         requestAnimationFrame(updateVideoFrame);
+        var map = ds_map_create();
+
+        ds_map_add(map, "type", "video_start");
+
+        g_pBuiltIn.async_load = map;
+        g_pObjectManager.ThrowEvent(EVENT_OTHER_SOCIAL, 0);
+        ds_map_destroy(map);
     }, true);
 		
 

--- a/scripts/yyVideo.js
+++ b/scripts/yyVideo.js
@@ -13,9 +13,6 @@
 // @if function("video_")
 var g_VideoUserEnded = false; //For some reason I can't figure this from the video player...
 var g_AnimationFrameRequestID = null;
-
-const cancelAnimationFrame =
-  window.cancelAnimationFrame || window.mozCancelAnimationFrame;
   
 const requestAnimationFrame =
   window.requestAnimationFrame ||
@@ -124,11 +121,6 @@ function video_open(path)
                         gameCanvas.videoContext.drawImage(gameCanvas.yyvideoplayer, 0, 0);
                         requestAnimationFrame(updateVideoFrame);
                     }
-                }
-            } else {
-                if (g_AnimationFrameRequestID !== null) {
-                    cancelAnimationFrame(g_AnimationFrameRequestID);
-                    g_AnimationFrameRequestID = null;
                 }
             }
         }

--- a/scripts/yyVideo.js
+++ b/scripts/yyVideo.js
@@ -12,6 +12,16 @@
 
 // @if function("video_")
 var g_VideoUserEnded = false; //For some reason I can't figure this from the video player...
+var g_AnimationFrameRequestID = null;
+
+const cancelAnimationFrame =
+  window.cancelAnimationFrame || window.mozCancelAnimationFrame;
+  
+const requestAnimationFrame =
+  window.requestAnimationFrame ||
+  window.mozRequestAnimationFrame ||
+  window.webkitRequestAnimationFrame ||
+  window.msRequestAnimationFrame;
 
 function video_get_format() {
     var video_format_rgba = 0;
@@ -93,27 +103,51 @@ function video_open(path)
 
     
     if (myVideo.requestVideoFrameCallback === undefined) { //urgh can't use nice fast playback
-        console.log("requestVideoFrameCallback not supported by browser, video playback likely to be poor");
-        myVideo.addEventListener('playing', function () {
-            playing = true;
-            console.log("Video playing event called");
-            checkReady();
+        console.log("requestVideoFrameCallback not supported by browser, falling back to requestAnimationFrame");
+        let fpsInterval = 1000 / 30;
+        let then = Date.now();
 
-            var map = ds_map_create();
+        function updateVideoFrame() {
+            if (!g_VideoUserEnded) {
+                g_AnimationFrameRequestID = requestAnimationFrame(updateVideoFrame);
+                let now = Date.now();
+                let elapsed = now - then;
 
-            ds_map_add(map, "type", "video_start");
+                if (elapsed > fpsInterval) {
+                    then = now - (elapsed % fpsInterval);
+                    if (gameCanvas.videoCanvas == null) {} else {
+                        gameCanvas.videoCanvas.width = myVideo.videoWidth;
+                        gameCanvas.videoCanvas.height = myVideo.videoHeight;
+                    }
 
-            g_pBuiltIn.async_load = map;
-            g_pObjectManager.ThrowEvent(EVENT_OTHER_SOCIAL, 0);
-            ds_map_destroy(map);
-
-        }, true);
+                    if ((gameCanvas.yyvideoplayer != null) && (gameCanvas.videoContext != null)) {
+                        gameCanvas.videoContext.drawImage(gameCanvas.yyvideoplayer, 0, 0);
+                        requestAnimationFrame(updateVideoFrame);
+                    }
+                }
+            } else {
+                if (g_AnimationFrameRequestID !== null) {
+                    cancelAnimationFrame(g_AnimationFrameRequestID);
+                    g_AnimationFrameRequestID = null;
+                }
+            }
+        }
+		
         myVideo.addEventListener('timeupdate', function () {
             timeupdate = true;
             checkReady();
         }, true);
 
         myVideo.load();
+		
+		myVideo.addEventListener('playing', function () {
+        playing = true;
+        console.log("Video playing event called");
+        checkReady();
+        requestAnimationFrame(updateVideoFrame);
+    }, true);
+		
+
 
         var promise = myVideo.play();
         if (promise !== undefined) {

--- a/scripts/yyVideo.js
+++ b/scripts/yyVideo.js
@@ -13,7 +13,7 @@
 // @if function("video_")
 var g_VideoUserEnded = false; //For some reason I can't figure this from the video player...
 var g_AnimationFrameRequestID = null;
-  
+
 const requestAnimationFrame =
   window.requestAnimationFrame ||
   window.mozRequestAnimationFrame ||
@@ -103,6 +103,21 @@ function video_open(path)
         console.log("requestVideoFrameCallback not supported by browser, falling back to requestAnimationFrame");
         let fpsInterval = 1000 / 30;
         let then = Date.now();
+
+        myVideo.addEventListener('playing', function () {
+            playing = true;
+            console.log("Video playing event called");
+            checkReady();
+
+            var map = ds_map_create();
+
+            ds_map_add(map, "type", "video_start");
+
+            g_pBuiltIn.async_load = map;
+            g_pObjectManager.ThrowEvent(EVENT_OTHER_SOCIAL, 0);
+            ds_map_destroy(map);
+
+        }, true);
 
         function updateVideoFrame() {
             if (!g_VideoUserEnded) {


### PR DESCRIPTION
Playing videos in HTML5 on Firefox has really bad laggy playback performance. This is a workaround using `requestAnimationFrame` which is compatible with Firefox/other browsers that don't support `requestVideoFrameCallback`. This was project-ruining on the game I'm working on, so I hope sharing this here will help some other people out who were running into this issue. 

One thing about this is I'm hardcoding the FPS to 30. I'm not sure if its possible to derive that directly from the video source or if the FPS should be defined inside the video object inside of Gamemaker.

I'm also wrapping the `updateVideoFrame` function in a conditional checking the state of `g_VideoUserEnded`, was encountering memory leak issues otherwise but it doesn't feel right to me. 