### PR TITLE
Fix crash in array_unique_ext

### DIFF
--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -1430,7 +1430,6 @@ function array_unique_ext(_array, _offset, _length) {
         if (!_set.has(_element)) {
             _array[_idx] = _element;
             _idx += _step;
-            _ret++;
         }
         
         _set.add(_element);


### PR DESCRIPTION
I've noticed that the function `array_unique_ext` crashes the game when called in HTML5 but not on desktop. Looking at the source, I found that the issue is due the undefined variable `_ret` being used in the function. In `array_map_ext` and `array_filter_ext`, `_ret` is used to count the number of valid elements in the array, but the return value `_set.size` in `array_unique_ext` does the same job, making `_ret` redundant.

I removed the `_ret++` from the function and now the HTML5 runner no longer crashes and still behaves consistently with the desktop platforms.

Test project: [array_unique_ext_test.zip](https://github.com/YoYoGames/GameMaker-HTML5/files/13907163/array_unique_ext_test.zip)
