### PR TITLE
Audio effect parameter tracks

### DIFF
--- a/scripts/functions/Function_Sequence.js
+++ b/scripts/functions/Function_Sequence.js
@@ -256,7 +256,7 @@ function sequence_track_new(_type)
 		case eSTT_Audio: pTrack = new yySequenceAudioTrack(); break;
 		case eSTT_Text: pTrack = new yySequenceTextTrack(); break;
 		case eSTT_Real: pTrack = new yySequenceRealTrack(); break;
-		case eSTT_Color: pTrack = new yySequenceColorTrack(); break;
+		case eSTT_Color: pTrack = new yySequenceColourTrack(); break;
 		case eSTT_Bool: pTrack = new yySequenceBoolTrack(); break;
 		case eSTT_String: pTrack = new yySequenceStringTrack(); break;
 		case eSTT_AudioEffect: pTrack = new yySequenceAudioEffectTrack(); break;

--- a/scripts/functions/Function_Sequence.js
+++ b/scripts/functions/Function_Sequence.js
@@ -140,6 +140,7 @@ function sequence_keyframestore_new(_type)
 		case eSTT_String:
 		case eSTT_Real:
 	    case eSTT_Color:
+		case eSTT_AudioEffect:
 	    case eSTT_Message:
         case eSTT_Moment:
             pKeyframeStore = new yyKeyframeStore(_type);
@@ -180,6 +181,7 @@ function sequence_keyframe_new(_type)
 		case eSTT_String:
 		case eSTT_Real:
 	    case eSTT_Color:
+		case eSTT_AudioEffect:
 	    case eSTT_Message:
         case eSTT_Moment:		
             pKeyframe = new yyKeyframe(_type);
@@ -220,6 +222,7 @@ function sequence_keyframedata_new(_type)
 		case eSTT_String: pKey = new yyStringTrackKey(); break;
 		case eSTT_Real: pKey = new yyRealTrackKey(); break;
 	    case eSTT_Color: pKey = new yyColorTrackKey(); break;
+		case eSTT_AudioEffect: pKey = new yyAudioEffectTrackKey(); break;
 	    case eSTT_Message: pKey = new yyMessageEventTrackKey(); break;
 		case eSTT_Moment: pKey = new yyMomentEventTrackKey(); break;
 		default: yyError("Unsupported keyframe type"); break;
@@ -256,6 +259,7 @@ function sequence_track_new(_type)
 		case eSTT_Color: pTrack = new yySequenceColorTrack(); break;
 		case eSTT_Bool: pTrack = new yySequenceBoolTrack(); break;
 		case eSTT_String: pTrack = new yySequenceStringTrack(); break;
+		case eSTT_AudioEffect: pTrack = new yySequenceAudioEffectTrack(); break;
 		case eSTT_Sequence: pTrack = new yySequenceSequenceTrack(); break;		
 		case eSTT_Particle: pTrack = new yySequenceParticleTrack(); break;
 		case eSTT_ClipMask: pTrack = new yySequenceClipMaskTrack(); break;

--- a/scripts/sound/AudioBus.js
+++ b/scripts/sound/AudioBus.js
@@ -148,6 +148,19 @@ AudioBus.isNodeIndex = function(_prop)
 	return false;
 };
 
+AudioBus.prototype.getParamDescriptors = function() {
+	return AudioBus.ParamDescriptors;
+};
+
+AudioBus.prototype.getParamDescriptor = function(_idx) {
+	return AudioBus.ParamDescriptors[_idx];
+};
+
+AudioBus.ParamDescriptors = [
+	{ name: "bypass", integer: true,  defaultValue: 0, minValue: 0, maxValue: 1 },
+	{ name: "gain",   integer: false, defaultValue: 1, minValue: 0, maxValue: Number.MAX_VALUE }
+];
+
 function DummyAudioBus() {
 	this.outputNode = Audio_CreateGainNode(g_WebAudioContext);
 

--- a/scripts/sound/AudioBus.js
+++ b/scripts/sound/AudioBus.js
@@ -92,21 +92,21 @@ AudioBus.prototype.findPrevNode = function(_idx)
 
 AudioBus.prototype.handleConnections = function(_idx, _newNodes)
 {
-	const currentNode = this.nodes[_idx];
+	const currentNodes = this.nodes[_idx];
 
-	if (currentNode === undefined && _newNodes === undefined)
+	if (currentNodes === undefined && _newNodes === undefined)
 		return; // No need to change anything
 
 	const prevNode = this.findPrevNode(_idx);
 	const nextNode = this.findNextNode(_idx);
 
 	// Disconnect the previous node
-	if (currentNode !== undefined)
+	if (currentNodes !== undefined)
 	{
-		prevNode.disconnect(currentNode);
+		prevNode.disconnect(currentNodes.input);
 
-		currentNode.disconnect();
-		this.effects[_idx].removeNode(currentNode);
+		currentNodes.output.disconnect();
+		this.effects[_idx].removeNode(currentNodes.output);
 	}
 	else
 	{

--- a/scripts/sound/AudioEffect.js
+++ b/scripts/sound/AudioEffect.js
@@ -144,11 +144,11 @@ AudioEffectStruct.prototype.setParam = function(_idx, _val) {
 AudioEffectStruct.prototype.getParamDescriptors = function() {
     const structType = AudioEffectStruct.GetStructType(this.type);
     return structType.ParamDescriptors;
-}
+};
 
 AudioEffectStruct.prototype.getParamDescriptor = function(_idx) {
     return this.getParamDescriptors()[_idx];
-}
+};
 
 AudioEffectStruct.prototype.removeNode = function(_node) { 
     const idx = this.nodes.findIndex(elem => elem === _node);

--- a/scripts/sound/AudioEffect.js
+++ b/scripts/sound/AudioEffect.js
@@ -102,7 +102,9 @@ AudioEffectStruct.Index = {
     Bypass: 0
 };
 
-AudioEffectStruct.Bypass = { name: "bypass", integer: true, defaultValue: 0, minValue: 0, maxValue: 1 };
+AudioEffectStruct.ParamDescriptors = [
+    { name: "bypass", integer: true, defaultValue: 0, minValue: 0, maxValue: 1 }
+];
 
 AudioEffectStruct.prototype.addInstance = function() {
     const node = g_WorkletNodeManager.createEffect(this);
@@ -116,13 +118,11 @@ AudioEffectStruct.prototype.initParams = function(_params) {
     const descriptors = this.getParamDescriptors();
     
     descriptors.forEach((_desc, _idx) => {
-        const val = (() => {
-            if (_params === undefined || _params["gml" + _desc.name] === undefined) {
-                return _desc.defaultValue;
-            }
-
-            return _params["gml" + _desc.name];
-        })();
+        let val = _desc.defaultValue;
+    
+        if (_params !== undefined && _params["gml" + _desc.name] !== undefined) {
+            val = _params["gml" + _desc.name];
+        }
 
         this.setParam(_idx, val);
     });

--- a/scripts/sound/AudioEffect.js
+++ b/scripts/sound/AudioEffect.js
@@ -44,7 +44,7 @@ function AudioEffectStruct(_type) {
     this.nodes = [];
 
     this.type = _type;
-    this.params = {};
+    this.params = [];
     
     // Define user-facing properties
     Object.defineProperties(this, {
@@ -60,42 +60,49 @@ function AudioEffectStruct(_type) {
         gmlbypass: {
             enumerable: true,
             get: () => {
-                return this.params.bypass;  
+                return this.params[AudioEffectStruct.Index.Bypass];  
             },
             set: (_state) => {
-                this.setParam(AudioEffectStruct.paramDescriptors().bypass, _state);
+                const val = this.setParam(AudioEffectStruct.Index.Bypass, _state);
 
                 this.nodes.forEach((_node) => {
                     const bypass = _node.parameters.get("bypass");
-                    bypass.value = this.params.bypass;
+                    bypass.value = val;
                 });
             }
         }
     });
 }
 
-AudioEffectStruct.Create = function(_type, _params) {
+AudioEffectStruct.GetStructType = function(_type) {
     switch (_type)
     {
-        case AudioEffect.Type.Bitcrusher:   return new BitcrusherEffectStruct(_params);
-        case AudioEffect.Type.Delay:        return new DelayEffectStruct(_params);
-        case AudioEffect.Type.Gain:         return new GainEffectStruct(_params);
-        case AudioEffect.Type.HPF2:         return new HPF2EffectStruct(_params);
-        case AudioEffect.Type.LPF2:         return new LPF2EffectStruct(_params);
-        case AudioEffect.Type.Reverb1:      return new Reverb1EffectStruct(_params);
-        case AudioEffect.Type.Tremolo:      return new TremoloEffectStruct(_params);
-        case AudioEffect.Type.PeakEQ:       return new PeakEQEffectStruct(_params);
-        case AudioEffect.Type.HiShelf:      return new HiShelfEffectStruct(_params);
-        case AudioEffect.Type.LoShelf:      return new LoShelfEffectStruct(_params);
-        case AudioEffect.Type.EQ:           return new EQEffectStruct(_params);
-        case AudioEffect.Type.Compressor:   return new CompressorEffectStruct(_params);
-        default:                            return null;
+        case AudioEffect.Type.Bitcrusher:   return BitcrusherEffectStruct;
+        case AudioEffect.Type.Delay:        return DelayEffectStruct;
+        case AudioEffect.Type.Gain:         return GainEffectStruct;
+        case AudioEffect.Type.HPF2:         return HPF2EffectStruct;
+        case AudioEffect.Type.LPF2:         return LPF2EffectStruct;
+        case AudioEffect.Type.Reverb1:      return Reverb1EffectStruct;
+        case AudioEffect.Type.Tremolo:      return TremoloEffectStruct;
+        case AudioEffect.Type.PeakEQ:       return PeakEQEffectStruct;
+        case AudioEffect.Type.HiShelf:      return HiShelfEffectStruct;
+        case AudioEffect.Type.LoShelf:      return LoShelfEffectStruct;
+        case AudioEffect.Type.EQ:           return EQEffectStruct;
+        case AudioEffect.Type.Compressor:   return CompressorEffectStruct;
+        default:                            return undefined;
     }
 };
 
-AudioEffectStruct.paramDescriptors = () => ({
-    bypass: { name: "bypass", integer: true, defaultValue: 0, minValue: 0, maxValue: 1 }
-});
+AudioEffectStruct.Create = function(_type, _params) {
+    const structType = AudioEffectStruct.GetStructType(_type);
+    return (structType === undefined) ? undefined : new structType(_params);
+};
+
+AudioEffectStruct.Index = {
+    Bypass: 0
+};
+
+AudioEffectStruct.Bypass = { name: "bypass", integer: true, defaultValue: 0, minValue: 0, maxValue: 1 };
 
 AudioEffectStruct.prototype.addInstance = function() {
     const node = g_WorkletNodeManager.createEffect(this);
@@ -105,8 +112,10 @@ AudioEffectStruct.prototype.addInstance = function() {
     return ret;
 };
 
-AudioEffectStruct.prototype.initParams = function(_params, _descriptors) {
-    Object.values(_descriptors).forEach(_desc => {
+AudioEffectStruct.prototype.initParams = function(_params) {    
+    const descriptors = this.getParamDescriptors();
+    
+    descriptors.forEach((_desc, _idx) => {
         const val = (() => {
             if (_params === undefined || _params["gml" + _desc.name] === undefined) {
                 return _desc.defaultValue;
@@ -115,18 +124,31 @@ AudioEffectStruct.prototype.initParams = function(_params, _descriptors) {
             return _params["gml" + _desc.name];
         })();
 
-        this.setParam(_desc, val);
+        this.setParam(_idx, val);
     });
 };
 
-AudioEffectStruct.prototype.setParam = function(_desc, _val) {
-    _val = clamp(_val, _desc.minValue, _desc.maxValue);
+AudioEffectStruct.prototype.setParam = function(_idx, _val) {
+    const structType = AudioEffectStruct.GetStructType(this.type);
+    const desc = structType.ParamDescriptors[_idx];
 
-    if (_desc.integer === true)
+    _val = clamp(_val, desc.minValue, desc.maxValue);
+
+    if (desc.integer === true)
         _val = ~~_val;
 
-    this.params[_desc.name] = _val;
+    this.params[_idx] = _val;
+    return _val;
 };
+
+AudioEffectStruct.prototype.getParamDescriptors = function() {
+    const structType = AudioEffectStruct.GetStructType(this.type);
+    return structType.ParamDescriptors;
+}
+
+AudioEffectStruct.prototype.getParamDescriptor = function(_idx) {
+    return this.getParamDescriptors()[_idx];
+}
 
 AudioEffectStruct.prototype.removeNode = function(_node) { 
     const idx = this.nodes.findIndex(elem => elem === _node);
@@ -134,6 +156,34 @@ AudioEffectStruct.prototype.removeNode = function(_node) {
     if (idx !== -1) {
         g_WorkletNodeManager.killNode(this.nodes[idx]);
         this.nodes.splice(idx, 1);
+    }
+};
+
+AudioEffectStruct.prototype.updateFreqDesc = function(_desc) {
+    if (this.isFilter() === false) {
+        return _desc;
+    }
+
+    if (_desc.name !== "cutoff" && _desc.name !== "freq") {
+        return _desc;
+    }
+
+    _desc.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2, _desc.maxValue)
+                                       : _desc.maxValue;
+    _desc.defaultValue = Math.min(_desc.defaultValue, _desc.maxValue);
+    return _desc;
+};
+
+AudioEffectStruct.prototype.isFilter = function() {
+    switch (this.type) {
+        case AudioEffect.Type.HiShelf:
+        case AudioEffect.Type.HPF2:
+        case AudioEffect.Type.LoShelf:
+        case AudioEffect.Type.LPF2:
+        case AudioEffect.Type.PeakEQ:
+            return true;
+        default:
+            return false;
     }
 };
 // @endif

--- a/scripts/sound/effects/Bitcrusher.js
+++ b/scripts/sound/effects/Bitcrusher.js
@@ -67,7 +67,7 @@ function BitcrusherEffectStruct(_params) {
 }
 
 BitcrusherEffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Gain: 1,
     Factor: 2,
     Resolution: 3,
@@ -75,7 +75,7 @@ BitcrusherEffectStruct.Index = {
 };
 
 BitcrusherEffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
+    { name: "bypass",     integer: true,  defaultValue: 0,   minValue: 0,   maxValue: 1 },
     { name: "gain",       integer: false, defaultValue: 1.0, minValue: 0.0, maxValue: Number.MAX_VALUE },
     { name: "factor",     integer: true,  defaultValue: 20,  minValue: 1,   maxValue: 100 },
     { name: "resolution", integer: true,  defaultValue: 8,   minValue: 2,   maxValue: 16  },

--- a/scripts/sound/effects/Bitcrusher.js
+++ b/scripts/sound/effects/Bitcrusher.js
@@ -3,74 +3,82 @@ function BitcrusherEffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.Bitcrusher);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, BitcrusherEffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmlgain: {
             enumerable: true,
             get: () => {
-                return this.params.gain;
+                return this.params[BitcrusherEffectStruct.Index.Gain];
             },
             set: (_gain) => {
-                this.setParam(BitcrusherEffectStruct.paramDescriptors().gain, _gain);
+                const val = this.setParam(BitcrusherEffectStruct.Index.Gain, _gain);
 
                 this.nodes.forEach((_node) => {
                     const gain = _node.parameters.get("gain");
-                    gain.setTargetAtTime(this.params.gain, 0, AudioEffect.PARAM_TIME_CONSTANT);
+                    gain.setTargetAtTime(val, 0, AudioEffect.PARAM_TIME_CONSTANT);
                 });
             }
         },
         gmlfactor: {
             enumerable: true,
             get: () => {
-                return this.params.factor;
+                return this.params[BitcrusherEffectStruct.Index.Factor];
             },
             set: (_factor) => {
-                this.setParam(BitcrusherEffectStruct.paramDescriptors().factor, _factor);
+                const val = this.setParam(BitcrusherEffectStruct.Index.Factor, _factor);
 
                 this.nodes.forEach((_node) => {
                     const factor = _node.parameters.get("factor");
-                    factor.value = this.params.factor;
+                    factor.value = val;
                 });
             }
         },
         gmlresolution: {
             enumerable: true,
             get: () => {
-                return this.params.resolution;
+                return this.params[BitcrusherEffectStruct.Index.Resolution];
             },
             set: (_resolution) => {
-                this.setParam(BitcrusherEffectStruct.paramDescriptors().resolution, _resolution);
+                const val = this.setParam(BitcrusherEffectStruct.Index.Resolution, _resolution);
 
                 this.nodes.forEach((_node) => {
                     const resolution = _node.parameters.get("resolution");
-                    resolution.value = this.params.resolution;
+                    resolution.value = val;
                 });
             }
         },
         gmlmix: {
             enumerable: true,
             get: () => {
-                return this.params.mix;
+                return this.params[BitcrusherEffectStruct.Index.Mix];
             },
             set: (_mix) => {
-                this.setParam(BitcrusherEffectStruct.paramDescriptors().mix, _mix);
+                const val = this.setParam(BitcrusherEffectStruct.Index.Mix, _mix);
 
                 this.nodes.forEach((_node) => {
                     const mix = _node.parameters.get("mix");
-                    mix.setTargetAtTime(this.params.mix, 0, AudioEffect.PARAM_TIME_CONSTANT);
+                    mix.setTargetAtTime(val, 0, AudioEffect.PARAM_TIME_CONSTANT);
                 });
             }
         }
     });
 }
 
-BitcrusherEffectStruct.paramDescriptors = () => ({
-    bypass:     AudioEffectStruct.paramDescriptors().bypass,
-    gain:       { name: "gain",       integer: false, defaultValue: 1.0, minValue: 0.0, maxValue: Number.MAX_VALUE },
-    factor:     { name: "factor",     integer: true,  defaultValue: 20,  minValue: 1,   maxValue: 100 },
-    resolution: { name: "resolution", integer: true,  defaultValue: 8,   minValue: 2,   maxValue: 16  },
-    mix:        { name: "mix",        integer: false, defaultValue: 0.8, minValue: 0.0, maxValue: 1.0 }
-});
+BitcrusherEffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Gain: 1,
+    Factor: 2,
+    Resolution: 3,
+    Mix: 4
+};
+
+BitcrusherEffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "gain",       integer: false, defaultValue: 1.0, minValue: 0.0, maxValue: Number.MAX_VALUE },
+    { name: "factor",     integer: true,  defaultValue: 20,  minValue: 1,   maxValue: 100 },
+    { name: "resolution", integer: true,  defaultValue: 8,   minValue: 2,   maxValue: 16  },
+    { name: "mix",        integer: false, defaultValue: 0.8, minValue: 0.0, maxValue: 1.0 }
+];
 // @endif

--- a/scripts/sound/effects/Compressor.js
+++ b/scripts/sound/effects/Compressor.js
@@ -94,7 +94,7 @@ function CompressorEffectStruct(_params) {
 }
 
 CompressorEffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     InGain: 1,
     Threshold: 2,
     Ratio: 3,
@@ -104,7 +104,7 @@ CompressorEffectStruct.Index = {
 };
 
 CompressorEffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
+    { name: "bypass",    integer: true,  defaultValue: 0,     minValue: 0,    maxValue: 1 },
     { name: "ingain",    integer: false, defaultValue: 1,     minValue: 1e-6, maxValue: Number.MAX_VALUE },
     { name: "threshold", integer: false, defaultValue: 0.125, minValue: 1e-3, maxValue: 1 },
     { name: "ratio",     integer: false, defaultValue: 4,     minValue: 1,    maxValue: Number.MAX_VALUE },

--- a/scripts/sound/effects/Compressor.js
+++ b/scripts/sound/effects/Compressor.js
@@ -3,103 +3,113 @@ function CompressorEffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.Compressor);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, CompressorEffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     Object.defineProperties(this, {
         gmlingain: {
             enumerable: true,
             get: () => {
-                return this.params.ingain;
+                return this.params[CompressorEffectStruct.Index.InGain];
             },
             set: (_ingain) => {
-                this.setParam(CompressorEffectStruct.paramDescriptors().ingain, _ingain);
+                const val = this.setParam(CompressorEffectStruct.Index.InGain, _ingain);
 
                 this.nodes.forEach((_node) => {
                     const ingain = _node.parameters.get("ingain");
-                    ingain.value = this.params.ingain;
+                    ingain.value = val;
                 });
             }
         },
         gmlthreshold: {
             enumerable: true,
             get: () => {
-                return this.params.threshold;
+                return this.params[CompressorEffectStruct.Index.Threshold];
             },
             set: (_threshold) => {
-                this.setParam(CompressorEffectStruct.paramDescriptors().threshold, _threshold);
+                const val = this.setParam(CompressorEffectStruct.Index.Threshold, _threshold);
 
                 this.nodes.forEach((_node) => {
                     const threshold = _node.parameters.get("threshold");
-                    threshold.value = this.params.threshold;
+                    threshold.value = val;
                 });
             }
         },
         gmlratio: {
             enumerable: true,
             get: () => {
-                return this.params.ratio;
+                return this.params[CompressorEffectStruct.Index.Ratio];
             },
             set: (_ratio) => {
-                this.setParam(CompressorEffectStruct.paramDescriptors().ratio, _ratio);
+                const val = this.setParam(CompressorEffectStruct.Index.Ratio, _ratio);
 
                 this.nodes.forEach((_node) => {
                     const ratio = _node.parameters.get("ratio");
-                    ratio.value = this.params.ratio;
+                    ratio.value = val;
                 });
             }
         },
         gmlattack: {
             enumerable: true,
             get: () => {
-                return this.params.attack;
+                return this.params[CompressorEffectStruct.Index.Attack];
             },
             set: (_attack) => {
-                this.setParam(CompressorEffectStruct.paramDescriptors().attack, _attack);
+                const val = this.setParam(CompressorEffectStruct.Index.Attack, _attack);
 
                 this.nodes.forEach((_node) => {
                     const attack = _node.parameters.get("attack");
-                    attack.value = this.params.attack;
+                    attack.value = val;
                 });
             }
         },
         gmlrelease: {
             enumerable: true,
             get: () => {
-                return this.params.release;
+                return this.params[CompressorEffectStruct.Index.Release];
             },
             set: (_release) => {
-                this.setParam(CompressorEffectStruct.paramDescriptors().release, _release);
+                const val = this.setParam(CompressorEffectStruct.Index.Release, _release);
 
                 this.nodes.forEach((_node) => {
                     const release = _node.parameters.get("release");
-                    release.value = this.params.release;
+                    release.value = val;
                 });
             }
         },
         gmloutgain: {
             enumerable: true,
             get: () => {
-                return this.params.outgain;
+                return this.params[CompressorEffectStruct.Index.OutGain];
             },
             set: (_outgain) => {
-                this.setParam(CompressorEffectStruct.paramDescriptors().outgain, _outgain);
+                const val = this.setParam(CompressorEffectStruct.Index.OutGain, _outgain);
 
                 this.nodes.forEach((_node) => {
                     const outgain = _node.parameters.get("outgain");
-                    outgain.value = this.params.outgain;
+                    outgain.value = val;
                 });
             }
         }
     });
 }
 
-CompressorEffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass,
-    ingain:    { name: "ingain",    integer: false, defaultValue: 1,     minValue: 1e-6, maxValue: Number.MAX_VALUE },
-    threshold: { name: "threshold", integer: false, defaultValue: 0.125, minValue: 1e-3, maxValue: 1 },
-    ratio:     { name: "ratio",     integer: false, defaultValue: 4,     minValue: 1,    maxValue: Number.MAX_VALUE },
-    attack:    { name: "attack",    integer: false, defaultValue: 0.05,  minValue: 1e-3, maxValue: 1e-1},
-    release:   { name: "release",   integer: false, defaultValue: 0.25,  minValue: 1e-2, maxValue: 1 },
-    outgain:   { name: "outgain",   integer: false, defaultValue: 1,     minValue: 1e-6, maxValue: Number.MAX_VALUE }
-});
+CompressorEffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    InGain: 1,
+    Threshold: 2,
+    Ratio: 3,
+    Attack: 4,
+    Release: 5,
+    OutGain: 6
+};
+
+CompressorEffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "ingain",    integer: false, defaultValue: 1,     minValue: 1e-6, maxValue: Number.MAX_VALUE },
+    { name: "threshold", integer: false, defaultValue: 0.125, minValue: 1e-3, maxValue: 1 },
+    { name: "ratio",     integer: false, defaultValue: 4,     minValue: 1,    maxValue: Number.MAX_VALUE },
+    { name: "attack",    integer: false, defaultValue: 0.05,  minValue: 1e-3, maxValue: 1e-1},
+    { name: "release",   integer: false, defaultValue: 0.25,  minValue: 1e-2, maxValue: 1 },
+    { name: "outgain",   integer: false, defaultValue: 1,     minValue: 1e-6, maxValue: Number.MAX_VALUE }
+];
 // @endif

--- a/scripts/sound/effects/Delay.js
+++ b/scripts/sound/effects/Delay.js
@@ -53,14 +53,14 @@ function DelayEffectStruct(_params) {
 }
 
 DelayEffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Time: 1,
     Feedback: 2,
     Mix: 3
 };
 
 DelayEffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
+    { name: "bypass",   integer: true,  defaultValue: 0,    minValue: 0,   maxValue: 1 },
     { name: "time",     integer: false, defaultValue: 0.2,  minValue: 0.0, maxValue: 5.0 },
     { name: "feedback", integer: false, defaultValue: 0.5,  minValue: 0.0, maxValue: 1.0 },
     { name: "mix",      integer: false, defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }

--- a/scripts/sound/effects/Delay.js
+++ b/scripts/sound/effects/Delay.js
@@ -3,59 +3,66 @@ function DelayEffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.Delay);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, DelayEffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmltime: {
             enumerable: true,
             get: () => {
-                return this.params.time;
+                return this.params[DelayEffectStruct.Index.Time];
             },
             set: (_time) => {
-                this.setParam(DelayEffectStruct.paramDescriptors().time, _time);
+                const val = this.setParam(DelayEffectStruct.Index.Time, _time);
 
                 this.nodes.forEach((_node) => {
                     const time = _node.parameters.get("time");
-                    time.setTargetAtTime(this.params.time, 0, AudioEffect.PARAM_TIME_CONSTANT);
+                    time.setTargetAtTime(val, 0, AudioEffect.PARAM_TIME_CONSTANT);
                 });
             }
         },
         gmlfeedback: {
             enumerable: true,
             get: () => {
-                return this.params.feedback;
+                return this.params[DelayEffectStruct.Index.Feedback];
             },
             set: (_feedback) => {
-                this.setParam(DelayEffectStruct.paramDescriptors().feedback, _feedback);
+                const val = this.setParam(DelayEffectStruct.Index.Feedback, _feedback);
 
                 this.nodes.forEach((_node) => {
                     const feedback = _node.parameters.get("feedback");
-                    feedback.setTargetAtTime(this.params.feedback, 0, AudioEffect.PARAM_TIME_CONSTANT);
+                    feedback.setTargetAtTime(val, 0, AudioEffect.PARAM_TIME_CONSTANT);
                 });
             }
         },
         gmlmix: {
             enumerable: true,
             get: () => {
-                return this.params.mix;
+                return this.params[DelayEffectStruct.Index.Mix];
             },
             set: (_mix) => {
-                this.setParam(DelayEffectStruct.paramDescriptors().mix, _mix);
+                const val = this.setParam(DelayEffectStruct.Index.Mix, _mix);
 
                 this.nodes.forEach((_node) => {
                     const mix = _node.parameters.get("mix");
-                    mix.setTargetAtTime(this.params.mix, 0, AudioEffect.PARAM_TIME_CONSTANT);
+                    mix.setTargetAtTime(val, 0, AudioEffect.PARAM_TIME_CONSTANT);
                 });
             }
         }
     });
 }
 
-DelayEffectStruct.paramDescriptors = () => ({
-    bypass:   AudioEffectStruct.paramDescriptors().bypass,
-    time:     { name: "time",     integer: false, defaultValue: 0.2,  minValue: 0.0, maxValue: 5.0 },
-    feedback: { name: "feedback", integer: false, defaultValue: 0.5,  minValue: 0.0, maxValue: 1.0 },
-    mix:      { name: "mix",      integer: false, defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
-});
+DelayEffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Time: 1,
+    Feedback: 2,
+    Mix: 3
+};
+
+DelayEffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "time",     integer: false, defaultValue: 0.2,  minValue: 0.0, maxValue: 5.0 },
+    { name: "feedback", integer: false, defaultValue: 0.5,  minValue: 0.0, maxValue: 1.0 },
+    { name: "mix",      integer: false, defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
+];
 // @endif

--- a/scripts/sound/effects/EQ.js
+++ b/scripts/sound/effects/EQ.js
@@ -3,7 +3,7 @@ function EQEffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.EQ);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, PeakEQEffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     const paramsWereGiven = (_params !== undefined);
 
@@ -56,7 +56,7 @@ function EQEffectStruct(_params) {
     }
 
     if (_params.gmlhicut === undefined) {
-        this.hicut.gmlcutoff = LPF2EffectStruct.paramDescriptors().cutoff.maxValue;
+        this.hicut.gmlcutoff = LPF2EffectStruct.ParamDescriptors[LPF2EffectStruct.Index.Cutoff].maxValue;
         this.hicut.gmlq = 1;
     }
 
@@ -176,7 +176,11 @@ function EQEffectStruct(_params) {
     };
 }
 
-EQEffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass
-});
+EQEffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass
+};
+
+EQEffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass
+];
 // @endif

--- a/scripts/sound/effects/EQ.js
+++ b/scripts/sound/effects/EQ.js
@@ -177,10 +177,10 @@ function EQEffectStruct(_params) {
 }
 
 EQEffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass
+    Bypass: 0
 };
 
 EQEffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass
+    { name: "bypass", integer: true, defaultValue: 0, minValue: 0, maxValue: 1 }
 ];
 // @endif

--- a/scripts/sound/effects/Gain.js
+++ b/scripts/sound/effects/Gain.js
@@ -3,29 +3,34 @@ function GainEffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.Gain);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, GainEffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmlgain: {
             enumerable: true,
             get: () => {
-                return this.params.gain;
+                return this.params[GainEffectStruct.Index.Gain];
             },
             set: (_gain) => {
-                this.setParam(GainEffectStruct.paramDescriptors().gain, _gain);
+                const val = this.setParam(GainEffectStruct.Index.Gain, _gain);
 
                 this.nodes.forEach((_node) => {
                     const gain = _node.parameters.get("gain");
-                    gain.value = this.params.gain;
+                    gain.value = val;
                 });
             }
         }
     });
 }
 
-GainEffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass,
-    gain:   { name: "gain", integer: false, defaultValue: 0.5, minValue: 0.0, maxValue: Number.MAX_VALUE }
-});
+GainEffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Gain: 1
+};
+
+GainEffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "gain", integer: false, defaultValue: 0.5, minValue: 0.0, maxValue: Number.MAX_VALUE }
+];
 // @endif

--- a/scripts/sound/effects/Gain.js
+++ b/scripts/sound/effects/Gain.js
@@ -25,12 +25,12 @@ function GainEffectStruct(_params) {
 }
 
 GainEffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Gain: 1
 };
 
 GainEffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
-    { name: "gain", integer: false, defaultValue: 0.5, minValue: 0.0, maxValue: Number.MAX_VALUE }
+    { name: "bypass", integer: true,  defaultValue: 0,   minValue: 0,   maxValue: 1 },
+    { name: "gain",   integer: false, defaultValue: 0.5, minValue: 0.0, maxValue: Number.MAX_VALUE }
 ];
 // @endif

--- a/scripts/sound/effects/HPF2.js
+++ b/scripts/sound/effects/HPF2.js
@@ -3,50 +3,50 @@ function HPF2EffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.HPF2);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, HPF2EffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmlcutoff: {
             enumerable: true,
             get: () => {
-                return this.params.cutoff;
+                return this.params[HPF2EffectStruct.Index.Cutoff];
             },
             set: (_cutoff) => {
-                this.setParam(HPF2EffectStruct.paramDescriptors().cutoff, _cutoff);
+                const val = this.setParam(HPF2EffectStruct.Index.Cutoff, _cutoff);
 
                 this.nodes.forEach((_node) => {
                     const cutoff = _node.parameters.get("cutoff");
-                    cutoff.value = this.params.cutoff;
+                    cutoff.value = val;
                 });
             }
         },
         gmlq: {
             enumerable: true,
             get: () => {
-                return this.params.q;
+                return this.params[HPF2EffectStruct.Index.Q];
             },
             set: (_q) => {
-                this.setParam(HPF2EffectStruct.paramDescriptors().q, _q);
+                const val = this.setParam(HPF2EffectStruct.Index.Q, _q);
 
                 this.nodes.forEach((_node) => {
                     const q = _node.parameters.get("q");
-                    q.value = this.params.q;
+                    q.value = val;
                 });
             }
         }
     });
 }
 
-HPF2EffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass,
-    freq:   { name: "cutoff", integer: false, defaultValue: 1500.0, minValue: 10.0, maxValue: 20000.0 },
-    q:      { name: "q",      integer: false, defaultValue: 1.5,    minValue: 1.0,  maxValue: 100.0 },
+HPF2EffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Cutoff: 1,
+    Q: 2
+};
 
-    get cutoff() {
-        this.freq.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2.0, this.freq.maxValue) : this.freq.maxValue;
-        this.freq.defaultValue = Math.min(this.freq.defaultValue, this.freq.maxValue);
-        return this.freq;
-    } 
-});
+HPF2EffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "cutoff", integer: false, defaultValue: 1500.0, minValue: 10.0, maxValue: 20000.0 },
+    { name: "q",      integer: false, defaultValue: 1.5,    minValue: 1.0,  maxValue: 100.0 }
+];
 // @endif

--- a/scripts/sound/effects/HPF2.js
+++ b/scripts/sound/effects/HPF2.js
@@ -39,13 +39,13 @@ function HPF2EffectStruct(_params) {
 }
 
 HPF2EffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Cutoff: 1,
     Q: 2
 };
 
 HPF2EffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
+    { name: "bypass", integer: true,  defaultValue: 0,      minValue: 0,    maxValue: 1 },
     { name: "cutoff", integer: false, defaultValue: 1500.0, minValue: 10.0, maxValue: 20000.0 },
     { name: "q",      integer: false, defaultValue: 1.5,    minValue: 1.0,  maxValue: 100.0 }
 ];

--- a/scripts/sound/effects/HiShelf.js
+++ b/scripts/sound/effects/HiShelf.js
@@ -3,65 +3,66 @@ function HiShelfEffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.HiShelf);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, HiShelfEffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmlfreq: {
             enumerable: true,
             get: () => {
-                return this.params.freq;
+                return this.params[HiShelfEffectStruct.Index.Freq];
             },
             set: (_freq) => {
-                this.setParam(HiShelfEffectStruct.paramDescriptors().freq, _freq);
+                const val = this.setParam(HiShelfEffectStruct.Index.Freq, _freq);
 
                 this.nodes.forEach((_node) => {
                     const freq = _node.parameters.get("freq");
-                    freq.value = this.params.freq;
+                    freq.value = val;
                 });
             }
         },
         gmlq: {
             enumerable: true,
             get: () => {
-                return this.params.q;
+                return this.params[HiShelfEffectStruct.Index.Q];
             },
             set: (_q) => {
-                this.setParam(HiShelfEffectStruct.paramDescriptors().q, _q);
+                const val = this.setParam(HiShelfEffectStruct.Index.Q, _q);
 
                 this.nodes.forEach((_node) => {
                     const q = _node.parameters.get("q");
-                    q.value = this.params.q;
+                    q.value = val;
                 });
             }
         },
         gmlgain: {
             enumerable: true,
             get: () => {
-                return this.params.gain;
+                return this.params[HiShelfEffectStruct.Index.Gain];
             },
             set: (_gain) => {
-                this.setParam(HiShelfEffectStruct.paramDescriptors().gain, _gain);
+                const val = this.setParam(HiShelfEffectStruct.Index.Gain, _gain);
 
                 this.nodes.forEach((_node) => {
                     const gain = _node.parameters.get("gain");
-                    gain.value = this.params.gain;
+                    gain.value = val;
                 });
             }
         }
     });
 }
 
-HiShelfEffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass,
-    __freq: { name: "freq",   integer: false, defaultValue: 5000.0, minValue: 10.0, maxValue: 20000.0 },
-    q:      { name: "q",      integer: false, defaultValue: 1.0,    minValue: 1.0,  maxValue: 100.0 },
-    gain:   { name: "gain",   integer: false, defaultValue: 1e-2,   minValue: 1e-6, maxValue: Number.MAX_VALUE },
+HiShelfEffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Freq: 1,
+    Q: 2,
+    Gain: 3
+};
 
-    get freq() {
-        this.__freq.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2.0, this.__freq.maxValue) : this.__freq.maxValue;
-        this.__freq.defaultValue = Math.min(this.__freq.defaultValue, this.__freq.maxValue);
-        return this.__freq;
-    } 
-});
+HiShelfEffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "freq",   integer: false, defaultValue: 5000.0, minValue: 10.0, maxValue: 20000.0 },
+    { name: "q",      integer: false, defaultValue: 1.0,    minValue: 1.0,  maxValue: 100.0 },
+    { name: "gain",   integer: false, defaultValue: 1e-2,   minValue: 1e-6, maxValue: Number.MAX_VALUE } 
+];
 // @endif

--- a/scripts/sound/effects/HiShelf.js
+++ b/scripts/sound/effects/HiShelf.js
@@ -53,14 +53,14 @@ function HiShelfEffectStruct(_params) {
 }
 
 HiShelfEffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Freq: 1,
     Q: 2,
     Gain: 3
 };
 
 HiShelfEffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
+    { name: "bypass", integer: true,  defaultValue: 0,      minValue: 0,    maxValue: 1 },
     { name: "freq",   integer: false, defaultValue: 5000.0, minValue: 10.0, maxValue: 20000.0 },
     { name: "q",      integer: false, defaultValue: 1.0,    minValue: 1.0,  maxValue: 100.0 },
     { name: "gain",   integer: false, defaultValue: 1e-2,   minValue: 1e-6, maxValue: Number.MAX_VALUE } 

--- a/scripts/sound/effects/LPF2.js
+++ b/scripts/sound/effects/LPF2.js
@@ -3,50 +3,50 @@ function LPF2EffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.LPF2);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, LPF2EffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmlcutoff: {
             enumerable: true,
             get: () => {
-                return this.params.cutoff;
+                return this.params[LPF2EffectStruct.Index.Cutoff];
             },
             set: (_cutoff) => {
-                this.setParam(LPF2EffectStruct.paramDescriptors().cutoff, _cutoff);
+                const val = this.setParam(LPF2EffectStruct.Index.Cutoff, _cutoff);
 
                 this.nodes.forEach((_node) => {
                     const cutoff = _node.parameters.get("cutoff");
-                    cutoff.value = this.params.cutoff;
+                    cutoff.value = val;
                 });
             }
         },
         gmlq: {
             enumerable: true,
             get: () => {
-                return this.params.q;
+                return this.params[LPF2EffectStruct.Index.Q];
             },
             set: (_q) => {
-                this.setParam(LPF2EffectStruct.paramDescriptors().q, _q);
+                const val = this.setParam(LPF2EffectStruct.Index.Q, _q);
 
                 this.nodes.forEach((_node) => {
                     const q = _node.parameters.get("q");
-                    q.value = this.params.q;
+                    q.value = val;
                 });
             }
         }
     });
 }
 
-LPF2EffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass,
-    freq:   { name: "cutoff", integer: false, defaultValue: 500.0, minValue: 10.0, maxValue: 20000.0 },
-    q:      { name: "q",      integer: false, defaultValue: 1.5,   minValue: 1.0,  maxValue: 100.0 },
+LPF2EffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Cutoff: 1,
+    Q: 2
+};
 
-    get cutoff() {
-        this.freq.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2.0, this.freq.maxValue) : this.freq.maxValue;
-        this.freq.defaultValue = Math.min(this.freq.defaultValue, this.freq.maxValue);
-        return this.freq;
-    } 
-});
+LPF2EffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "cutoff", integer: false, defaultValue: 500.0, minValue: 10.0, maxValue: 20000.0 },
+    { name: "q",      integer: false, defaultValue: 1.5,   minValue: 1.0,  maxValue: 100.0 } 
+];
 // @endif

--- a/scripts/sound/effects/LPF2.js
+++ b/scripts/sound/effects/LPF2.js
@@ -39,13 +39,13 @@ function LPF2EffectStruct(_params) {
 }
 
 LPF2EffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Cutoff: 1,
     Q: 2
 };
 
 LPF2EffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
+    { name: "bypass", integer: true,  defaultValue: 0,      minValue: 0,    maxValue: 1 },
     { name: "cutoff", integer: false, defaultValue: 500.0, minValue: 10.0, maxValue: 20000.0 },
     { name: "q",      integer: false, defaultValue: 1.5,   minValue: 1.0,  maxValue: 100.0 } 
 ];

--- a/scripts/sound/effects/LoShelf.js
+++ b/scripts/sound/effects/LoShelf.js
@@ -3,65 +3,66 @@ function LoShelfEffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.LoShelf);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, LoShelfEffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmlfreq: {
             enumerable: true,
             get: () => {
-                return this.params.freq;
+                return this.params[LoShelfEffectStruct.Index.Freq];
             },
             set: (_freq) => {
-                this.setParam(LoShelfEffectStruct.paramDescriptors().freq, _freq);
+                const val = this.setParam(LoShelfEffectStruct.Index.Freq, _freq);
 
                 this.nodes.forEach((_node) => {
                     const freq = _node.parameters.get("freq");
-                    freq.value = this.params.freq;
+                    freq.value = val;
                 });
             }
         },
         gmlq: {
             enumerable: true,
             get: () => {
-                return this.params.q;
+                return this.params[LoShelfEffectStruct.Index.Q];
             },
             set: (_q) => {
-                this.setParam(LoShelfEffectStruct.paramDescriptors().q, _q);
+                const val = this.setParam(LoShelfEffectStruct.Index.Q, _q);
 
                 this.nodes.forEach((_node) => {
                     const q = _node.parameters.get("q");
-                    q.value = this.params.q;
+                    q.value = val;
                 });
             }
         },
         gmlgain: {
             enumerable: true,
             get: () => {
-                return this.params.gain;
+                return this.params[LoShelfEffectStruct.Index.Gain];
             },
             set: (_gain) => {
-                this.setParam(LoShelfEffectStruct.paramDescriptors().gain, _gain);
+                const val = this.setParam(LoShelfEffectStruct.Index.Gain, _gain);
 
                 this.nodes.forEach((_node) => {
                     const gain = _node.parameters.get("gain");
-                    gain.value = this.params.gain;
+                    gain.value = val;
                 });
             }
         }
     });
 }
 
-LoShelfEffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass,
-    __freq: { name: "freq",   integer: false, defaultValue: 500.0,  minValue: 10.0, maxValue: 20000.0 },
-    q:      { name: "q",      integer: false, defaultValue: 1.0,    minValue: 1.0,  maxValue: 100.0 },
-    gain:   { name: "gain",   integer: false, defaultValue: 1e-2,   minValue: 1e-6, maxValue: Number.MAX_VALUE },
+LoShelfEffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Freq: 1,
+    Q: 2,
+    Gain: 3
+};
 
-    get freq() {
-        this.__freq.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2.0, this.__freq.maxValue) : this.__freq.maxValue;
-        this.__freq.defaultValue = Math.min(this.__freq.defaultValue, this.__freq.maxValue);
-        return this.__freq;
-    } 
-});
+LoShelfEffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "freq",   integer: false, defaultValue: 500.0,  minValue: 10.0, maxValue: 20000.0 },
+    { name: "q",      integer: false, defaultValue: 1.0,    minValue: 1.0,  maxValue: 100.0 },
+    { name: "gain",   integer: false, defaultValue: 1e-2,   minValue: 1e-6, maxValue: Number.MAX_VALUE }
+];
 // @endif

--- a/scripts/sound/effects/LoShelf.js
+++ b/scripts/sound/effects/LoShelf.js
@@ -53,14 +53,14 @@ function LoShelfEffectStruct(_params) {
 }
 
 LoShelfEffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Freq: 1,
     Q: 2,
     Gain: 3
 };
 
 LoShelfEffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
+    { name: "bypass", integer: true,  defaultValue: 0,      minValue: 0,    maxValue: 1 },
     { name: "freq",   integer: false, defaultValue: 500.0,  minValue: 10.0, maxValue: 20000.0 },
     { name: "q",      integer: false, defaultValue: 1.0,    minValue: 1.0,  maxValue: 100.0 },
     { name: "gain",   integer: false, defaultValue: 1e-2,   minValue: 1e-6, maxValue: Number.MAX_VALUE }

--- a/scripts/sound/effects/PeakEQ.js
+++ b/scripts/sound/effects/PeakEQ.js
@@ -3,65 +3,66 @@ function PeakEQEffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.PeakEQ);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, PeakEQEffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmlfreq: {
             enumerable: true,
             get: () => {
-                return this.params.freq;
+                return this.params[PeakEQEffectStruct.Index.Freq];
             },
             set: (_freq) => {
-                this.setParam(PeakEQEffectStruct.paramDescriptors().freq, _freq);
+                const val = this.setParam(PeakEQEffectStruct.Index.Freq, _freq);
 
                 this.nodes.forEach((_node) => {
                     const freq = _node.parameters.get("freq");
-                    freq.value = this.params.freq;
+                    freq.value = val;
                 });
             }
         },
         gmlq: {
             enumerable: true,
             get: () => {
-                return this.params.q;
+                return this.params[PeakEQEffectStruct.Index.Freq];
             },
             set: (_q) => {
-                this.setParam(PeakEQEffectStruct.paramDescriptors().q, _q);
+                const val = this.setParam(PeakEQEffectStruct.Index.Q, _q);
 
                 this.nodes.forEach((_node) => {
                     const q = _node.parameters.get("q");
-                    q.value = this.params.q;
+                    q.value = val;
                 });
             }
         },
         gmlgain: {
             enumerable: true,
             get: () => {
-                return this.params.gain;
+                return this.params[PeakEQEffectStruct.Index.Freq];
             },
             set: (_gain) => {
-                this.setParam(PeakEQEffectStruct.paramDescriptors().gain, _gain);
+                const val = this.setParam(PeakEQEffectStruct.Index.Gain, _gain);
 
                 this.nodes.forEach((_node) => {
                     const gain = _node.parameters.get("gain");
-                    gain.value = this.params.gain;
+                    gain.value = val;
                 });
             }
         }
     });
 }
 
-PeakEQEffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass,
-    __freq: { name: "freq",   integer: false, defaultValue: 1500.0, minValue: 10.0, maxValue: 20000.0 },
-    q:      { name: "q",      integer: false, defaultValue: 1.0,    minValue: 1.0,  maxValue: 100.0 },
-    gain:   { name: "gain",   integer: false, defaultValue: 1e-2,   minValue: 1e-6, maxValue: Number.MAX_VALUE },
+PeakEQEffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Freq: 1,
+    Q: 2,
+    Gain: 3
+};
 
-    get freq() {
-        this.__freq.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2.0, this.__freq.maxValue) : this.__freq.maxValue;
-        this.__freq.defaultValue = Math.min(this.__freq.defaultValue, this.__freq.maxValue);
-        return this.__freq;
-    } 
-});
+PeakEQEffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "freq",   integer: false, defaultValue: 1500.0, minValue: 10.0, maxValue: 20000.0 },
+    { name: "q",      integer: false, defaultValue: 1.0,    minValue: 1.0,  maxValue: 100.0 },
+    { name: "gain",   integer: false, defaultValue: 1e-2,   minValue: 1e-6, maxValue: Number.MAX_VALUE }
+];
 // @endif

--- a/scripts/sound/effects/PeakEQ.js
+++ b/scripts/sound/effects/PeakEQ.js
@@ -53,14 +53,14 @@ function PeakEQEffectStruct(_params) {
 }
 
 PeakEQEffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Freq: 1,
     Q: 2,
     Gain: 3
 };
 
 PeakEQEffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
+    { name: "bypass", integer: true,  defaultValue: 0,      minValue: 0,    maxValue: 1 },
     { name: "freq",   integer: false, defaultValue: 1500.0, minValue: 10.0, maxValue: 20000.0 },
     { name: "q",      integer: false, defaultValue: 1.0,    minValue: 1.0,  maxValue: 100.0 },
     { name: "gain",   integer: false, defaultValue: 1e-2,   minValue: 1e-6, maxValue: Number.MAX_VALUE }

--- a/scripts/sound/effects/Reverb1.js
+++ b/scripts/sound/effects/Reverb1.js
@@ -53,16 +53,16 @@ function Reverb1EffectStruct(_params) {
 }
 
 Reverb1EffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Size: 1,
     Damp: 2,
     Mix: 3
 };
 
 Reverb1EffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
-    { name: "size", integer: false, defaultValue: 0.7,  minValue: 0.0, maxValue: 1.0 },
-    { name: "damp", integer: false, defaultValue: 0.1,  minValue: 0.0, maxValue: 1.0 },
-    { name: "mix",  integer: false, defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
+    { name: "bypass", integer: true,  defaultValue: 0,    minValue: 0,   maxValue: 1 },
+    { name: "size",   integer: false, defaultValue: 0.7,  minValue: 0.0, maxValue: 1.0 },
+    { name: "damp",   integer: false, defaultValue: 0.1,  minValue: 0.0, maxValue: 1.0 },
+    { name: "mix",    integer: false, defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
 ];
 // @endif

--- a/scripts/sound/effects/Reverb1.js
+++ b/scripts/sound/effects/Reverb1.js
@@ -3,59 +3,66 @@ function Reverb1EffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.Reverb1);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, Reverb1EffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmlsize: {
             enumerable: true,
             get: () => {
-                return this.params.size;
+                return this.params[Reverb1EffectStruct.Index.Size];
             },
             set: (_size) => {
-                this.setParam(Reverb1EffectStruct.paramDescriptors().size, _size);
+                const val = this.setParam(Reverb1EffectStruct.Index.Size, _size);
 
                 this.nodes.forEach((_node) => {
                     const size = _node.parameters.get("size");
-                    size.value = this.params.size;
+                    size.value = val;
                 });
             }
         },
         gmldamp: {
             enumerable: true,
             get: () => {
-                return this.params.damp;
+                return this.params[Reverb1EffectStruct.Index.Damp];
             },
             set: (_damp) => {
-                this.setParam(Reverb1EffectStruct.paramDescriptors().damp, _damp);
+                const val = this.setParam(Reverb1EffectStruct.Index.Damp, _damp);
 
                 this.nodes.forEach((_node) => {
                     const damp = _node.parameters.get("damp");
-                    damp.value = this.params.damp;
+                    damp.value = val;
                 });
             }
         },
         gmlmix: {
             enumerable: true,
             get: () => {
-                return this.params.mix;
+                return this.params[Reverb1EffectStruct.Index.Mix];
             },
             set: (_mix) => {
-                this.setParam(Reverb1EffectStruct.paramDescriptors().mix, _mix);
+                const val = this.setParam(Reverb1EffectStruct.Index.Mix, _mix);
 
                 this.nodes.forEach((_node) => {
                     const mix = _node.parameters.get("mix");
-                    mix.setTargetAtTime(this.params.mix, 0, AudioEffect.PARAM_TIME_CONSTANT);
+                    mix.setTargetAtTime(val, 0, AudioEffect.PARAM_TIME_CONSTANT);
                 });
             }
         }
     });
 }
 
-Reverb1EffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass,
-    size:   { name: "size", integer: false, defaultValue: 0.7,  minValue: 0.0, maxValue: 1.0 },
-    damp:   { name: "damp", integer: false, defaultValue: 0.1,  minValue: 0.0, maxValue: 1.0 },
-    mix:    { name: "mix",  integer: false, defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
-});
+Reverb1EffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Size: 1,
+    Damp: 2,
+    Mix: 3
+};
+
+Reverb1EffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "size", integer: false, defaultValue: 0.7,  minValue: 0.0, maxValue: 1.0 },
+    { name: "damp", integer: false, defaultValue: 0.1,  minValue: 0.0, maxValue: 1.0 },
+    { name: "mix",  integer: false, defaultValue: 0.35, minValue: 0.0, maxValue: 1.0 }
+];
 // @endif

--- a/scripts/sound/effects/Tremolo.js
+++ b/scripts/sound/effects/Tremolo.js
@@ -67,7 +67,7 @@ function TremoloEffectStruct(_params) {
 }
 
 TremoloEffectStruct.Index = {
-    Bypass: AudioEffectStruct.Index.Bypass,
+    Bypass: 0,
     Rate: 1,
     Intensity: 2,
     Offset: 3,
@@ -75,7 +75,7 @@ TremoloEffectStruct.Index = {
 };
 
 TremoloEffectStruct.ParamDescriptors = [
-    AudioEffectStruct.Bypass,
+    { name: "bypass",    integer: true,  defaultValue: 0,   minValue: 0,   maxValue: 1 },
     { name: "rate",      integer: false, defaultValue: 5.0, minValue: 0.0, maxValue: 20.0 },
     { name: "intensity", integer: false, defaultValue: 1.0, minValue: 0.0, maxValue: 1.0 },
     { name: "offset",    integer: false, defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },

--- a/scripts/sound/effects/Tremolo.js
+++ b/scripts/sound/effects/Tremolo.js
@@ -13,7 +13,7 @@ function TremoloEffectStruct(_params) {
                 return this.params[TremoloEffectStruct.Index.Rate];
             },
             set: (_rate) => {
-                const val = this.setParam(TremoloEffectStruct.Index, _rate);
+                const val = this.setParam(TremoloEffectStruct.Index.Rate, _rate);
 
                 this.nodes.forEach((_node) => {
                     const rate = _node.parameters.get("rate");
@@ -27,7 +27,7 @@ function TremoloEffectStruct(_params) {
                 return this.params[TremoloEffectStruct.Index.Intensity];
             },
             set: (_intensity) => {
-                const val = this.setParam(TremoloEffectStruct.Intensity, _intensity);
+                const val = this.setParam(TremoloEffectStruct.Index.Intensity, _intensity);
 
                 this.nodes.forEach((_node) => {
                     const intensity = _node.parameters.get("intensity");
@@ -41,7 +41,7 @@ function TremoloEffectStruct(_params) {
                 return this.params[TremoloEffectStruct.Index.Offset];
             },
             set: (_offset) => {
-                const val = this.setParam(TremoloEffectStruct.Offset, _offset);
+                const val = this.setParam(TremoloEffectStruct.Index.Offset, _offset);
 
                 this.nodes.forEach((_node) => {
                     const offset = _node.parameters.get("offset");
@@ -55,7 +55,7 @@ function TremoloEffectStruct(_params) {
                 return this.params[TremoloEffectStruct.Index.Shape];
             },
             set: (_shape) => {
-                const val = this.setParam(TremoloEffectStruct.Shape, _shape);
+                const val = this.setParam(TremoloEffectStruct.Index.Shape, _shape);
 
                 this.nodes.forEach((_node) => {
                     const shape = _node.parameters.get("shape");

--- a/scripts/sound/effects/Tremolo.js
+++ b/scripts/sound/effects/Tremolo.js
@@ -3,74 +3,82 @@ function TremoloEffectStruct(_params) {
     AudioEffectStruct.call(this, AudioEffect.Type.Tremolo);
     Object.setPrototypeOf(this, AudioEffectStruct.prototype);
 
-    this.initParams(_params, TremoloEffectStruct.paramDescriptors());
+    this.initParams(_params);
 
     // Define user-facing properties
     Object.defineProperties(this, {
         gmlrate: {
             enumerable: true,
             get: () => {
-                return this.params.rate;
+                return this.params[TremoloEffectStruct.Index.Rate];
             },
             set: (_rate) => {
-                this.setParam(TremoloEffectStruct.paramDescriptors().rate, _rate);
+                const val = this.setParam(TremoloEffectStruct.Index, _rate);
 
                 this.nodes.forEach((_node) => {
                     const rate = _node.parameters.get("rate");
-                    rate.value = this.params.rate;
+                    rate.value = val;
                 });
             }
         },
         gmlintensity: {
             enumerable: true,
             get: () => {
-                return this.params.intensity;
+                return this.params[TremoloEffectStruct.Index.Intensity];
             },
             set: (_intensity) => {
-                this.setParam(TremoloEffectStruct.paramDescriptors().intensity, _intensity);
+                const val = this.setParam(TremoloEffectStruct.Intensity, _intensity);
 
                 this.nodes.forEach((_node) => {
                     const intensity = _node.parameters.get("intensity");
-                    intensity.setTargetAtTime(this.params.intensity, 0, AudioEffect.PARAM_TIME_CONSTANT);
+                    intensity.setTargetAtTime(val, 0, AudioEffect.PARAM_TIME_CONSTANT);
                 });
             }
         },
         gmloffset: {
             enumerable: true,
             get: () => {
-                return this.params.offset;
+                return this.params[TremoloEffectStruct.Index.Offset];
             },
             set: (_offset) => {
-                this.setParam(TremoloEffectStruct.paramDescriptors().offset, _offset);
+                const val = this.setParam(TremoloEffectStruct.Offset, _offset);
 
                 this.nodes.forEach((_node) => {
                     const offset = _node.parameters.get("offset");
-                    offset.value = this.params.offset;
+                    offset.value = val;
                 });
             }
         },
         gmlshape: {
             enumerable: true,
             get: () => {
-                return this.params.shape;
+                return this.params[TremoloEffectStruct.Index.Shape];
             },
             set: (_shape) => {
-                this.setParam(TremoloEffectStruct.paramDescriptors().shape, _shape);
+                const val = this.setParam(TremoloEffectStruct.Shape, _shape);
 
                 this.nodes.forEach((_node) => {
                     const shape = _node.parameters.get("shape");
-                    shape.value = this.params.shape;
+                    shape.value = val;
                 });
             }
         }
     });
 }
 
-TremoloEffectStruct.paramDescriptors = () => ({
-    bypass: AudioEffectStruct.paramDescriptors().bypass,
-    rate:      { name: "rate",      integer: false, defaultValue: 5.0, minValue: 0.0, maxValue: 20.0 },
-    intensity: { name: "intensity", integer: false, defaultValue: 1.0, minValue: 0.0, maxValue: 1.0 },
-    offset:    { name: "offset",    integer: false, defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
-    shape:     { name: "shape",     integer: true,  defaultValue: 0,   minValue: 0,   maxValue: 4 }
-});
+TremoloEffectStruct.Index = {
+    Bypass: AudioEffectStruct.Index.Bypass,
+    Rate: 1,
+    Intensity: 2,
+    Offset: 3,
+    Shape: 4
+};
+
+TremoloEffectStruct.ParamDescriptors = [
+    AudioEffectStruct.Bypass,
+    { name: "rate",      integer: false, defaultValue: 5.0, minValue: 0.0, maxValue: 20.0 },
+    { name: "intensity", integer: false, defaultValue: 1.0, minValue: 0.0, maxValue: 1.0 },
+    { name: "offset",    integer: false, defaultValue: 0.0, minValue: 0.0, maxValue: 1.0 },
+    { name: "shape",     integer: true,  defaultValue: 0,   minValue: 0,   maxValue: 4 }
+];
 // @endif

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -91,19 +91,19 @@ eSTT_Real = 3;
 eSTT_Color = 4;
 eSTT_Bool = 5;
 eSTT_String = 6;
-eSTT_AudioEffect = 7;
-eSTT_Sequence = 8;
-eSTT_ClipMask = 9;
-eSTT_ClipMask_Mask = 10;
-eSTT_ClipMask_Subject = 11;
-eSTT_Group = 12;
-eSTT_Empty = 13;
-eSTT_SpriteFrames = 14;
-eSTT_Instance = 15;
-eSTT_Message = 16;
-eSTT_Moment = 17;
-eSTT_Text = 18;
-eSTT_Particle = 19;
+eSTT_Sequence = 7;
+eSTT_ClipMask = 8;
+eSTT_ClipMask_Mask = 9;
+eSTT_ClipMask_Subject = 10;
+eSTT_Group = 11;
+eSTT_Empty = 12;
+eSTT_SpriteFrames = 13;
+eSTT_Instance = 14;
+eSTT_Message = 15;
+eSTT_Moment = 16;
+eSTT_Text = 17;
+eSTT_Particle = 18;
+eSTT_AudioEffect = 19;
 eSTT_Max = 20;
 
 // @if feature("sequences")
@@ -156,7 +156,7 @@ eT_AudioEffect_Hishelf = 39;
 eT_AudioEffect_Hpf2 = 40;
 eT_AudioEffect_Loshelf = 41;
 eT_AudioEffect_Lpf2 = 42;
-eT_AudioEffect_PeakEQ = 43;
+eT_AudioEffect_Peakeq = 43;
 eT_AudioEffect_Reverb1 = 44;
 eT_AudioEffect_Tremolo = 45;
 
@@ -1010,7 +1010,7 @@ function yySequenceAudioEffectTrack(_pStorage) {
             case eT_AudioEffect_Hpf2:		return AudioEffect.Type.HPF2;
             case eT_AudioEffect_Loshelf:	return AudioEffect.Type.LoShelf;
             case eT_AudioEffect_Lpf2:		return AudioEffect.Type.LPF2;
-            case eT_AudioEffect_PeakEQ:		return AudioEffect.Type.PeakEQ;
+            case eT_AudioEffect_Peakeq:		return AudioEffect.Type.PeakEQ;
             case eT_AudioEffect_Reverb1:	return AudioEffect.Type.Reverb1;
             case eT_AudioEffect_Tremolo:	return AudioEffect.Type.Tremolo;
             default:
@@ -2296,7 +2296,7 @@ function yySequenceBaseTrack(_pStorage) {
                     case eT_AudioEffect_Gain:
                     case eT_AudioEffect_Hishelf:
                     case eT_AudioEffect_Loshelf:
-                    case eT_AudioEffect_PeakEQ:
+                    case eT_AudioEffect_Peakeq:
                     case eT_AudioEffect_Hpf2:
                     case eT_AudioEffect_Lpf2:
                     case eT_AudioEffect_Reverb1:
@@ -2362,6 +2362,18 @@ function yySequenceBaseTrack(_pStorage) {
         else if (this.pName == "textEffect_shadowSoftness") this.builtinName = eT_TextEffect_ShadowSoftness;
         else if (this.pName == "textEffect_shadowOffset") this.builtinName = eT_TextEffect_ShadowOffset;
         else if (this.pName == "textEffect_shadowColour") this.builtinName = eT_TextEffect_ShadowColour;
+        else if (this.pName == "audioEffect_bus") this.builtinName = eT_AudioEffect_Bus;
+        else if (this.pName == "audioEffect_bitcrusher") this.builtinName = eT_AudioEffect_Bitcrusher;
+        else if (this.pName == "audioEffect_compressor") this.builtinName = eT_AudioEffect_Compressor;
+        else if (this.pName == "audioEffect_delay") this.builtinName = eT_AudioEffect_Delay;
+        else if (this.pName == "audioEffect_gain") this.builtinName = eT_AudioEffect_Gain;
+        else if (this.pName == "audioEffect_hishelf") this.builtinName = eT_AudioEffect_Hishelf;
+        else if (this.pName == "audioEffect_hpf2") this.builtinName = eT_AudioEffect_Hpf2;
+        else if (this.pName == "audioEffect_loshelf") this.builtinName = eT_AudioEffect_Loshelf;
+        else if (this.pName == "audioEffect_lpf2") this.builtinName = eT_AudioEffect_Lpf2;
+        else if (this.pName == "audioEffect_peakeq") this.builtinName = eT_AudioEffect_Peakeq;
+        else if (this.pName == "audioEffect_reverb1") this.builtinName = eT_AudioEffect_Reverb1;
+        else if (this.pName == "audioEffect_tremolo") this.builtinName = eT_AudioEffect_Tremolo;
         else this.builtinName = eT_UserDefined;
     };
     // @endif

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -91,23 +91,25 @@ eSTT_Real = 3;
 eSTT_Color = 4;
 eSTT_Bool = 5;
 eSTT_String = 6;
-eSTT_Sequence = 7;
-eSTT_ClipMask = 8;
-eSTT_ClipMask_Mask = 9;
-eSTT_ClipMask_Subject = 10;
-eSTT_Group = 11;
-eSTT_Empty = 12;
-eSTT_SpriteFrames = 13;
-eSTT_Instance = 14;
-eSTT_Message = 15;
-eSTT_Moment = 16;
-eSTT_Text = 17;
-eSTT_Particle = 18;
-eSTT_Max = 19;
+eSTT_AudioEffect = 7;
+eSTT_Sequence = 8;
+eSTT_ClipMask = 9;
+eSTT_ClipMask_Mask = 10;
+eSTT_ClipMask_Subject = 11;
+eSTT_Group = 12;
+eSTT_Empty = 13;
+eSTT_SpriteFrames = 14;
+eSTT_Instance = 15;
+eSTT_Message = 16;
+eSTT_Moment = 17;
+eSTT_Text = 18;
+eSTT_Particle = 19;
+eSTT_Max = 20;
 
 // @if feature("sequences")
 
-function TrackIsParameter(type) { return (type == eSTT_Real || type == eSTT_Color || type == eSTT_Bool || type == eSTT_String); }
+function TrackIsParameter(type) { return (type == eSTT_Real || type == eSTT_Color || type == eSTT_Bool
+    || type == eSTT_String || type == eSTT_AudioEffect); }
 
 eT_UserDefined = 0;
 __X__ = 1;
@@ -145,10 +147,23 @@ eT_TextEffect_ShadowSoftness = 31;
 eT_TextEffect_ShadowOffset = 32;
 eT_TextEffect_ShadowColour = 33;
 
+eT_AudioEffect_Bus = 34;
+eT_AudioEffect_Bitcrusher = 35;
+eT_AudioEffect_Compressor = 36;
+eT_AudioEffect_Delay = 37;
+eT_AudioEffect_Gain = 38;
+eT_AudioEffect_Hishelf = 39;
+eT_AudioEffect_Hpf2 = 40;
+eT_AudioEffect_Loshelf = 41;
+eT_AudioEffect_Lpf2 = 42;
+eT_AudioEffect_PeakEQ = 43;
+eT_AudioEffect_Reverb1 = 44;
+eT_AudioEffect_Tremolo = 45;
+
 // Extras only in the runner
-eT_OriginX = 34;
-eT_OriginY = 35;
-eT_HeadPosChanged = 36;
+eT_OriginX = 46;
+eT_OriginY = 47;
+eT_HeadPosChanged = 48;
 
 eACCT_Linear = 0;
 eACCT_CatmullRom_Centripetal = 1;
@@ -307,6 +322,7 @@ function SequenceBaseTrack_Load(_pStorage) {
             case "GMClipMask_Subject": newTrack = new yySequenceClipMask_SubjectTrack(_pStorage); break;
             case "GMStringTrack": newTrack = new yySequenceStringTrack(_pStorage); break;
             case "GMBoolTrack": newTrack = new yySequenceBoolTrack(_pStorage); break;
+            case "GMAudioEffectTrack": newTrack = new yySequenceAudioEffectTrack(_pStorage); break;
             // @endif
         }
 
@@ -498,7 +514,7 @@ function yySequenceRealTrack(_pStorage) {
     };
     
     //calculate accumulated frames travelled (area under image speed keys) from _startKey to _key
-//returns true if _res is set
+    //returns true if _res is set
     this.calculateAnimDistance = function(_channel, _startKey, _key, _seqlength, _res)
     {
 	    var pRes = null;
@@ -579,6 +595,447 @@ function yySequenceRealTrack(_pStorage) {
 
 	    pRes = yymax(dtotal,0);
 	    return pRes;
+    };
+}
+
+// #############################################################################################
+/// Function:<summary>
+///             Create a new Real Track object
+///          </summary>
+// #############################################################################################
+/** @constructor */
+function yySequenceAudioEffectTrack(_pStorage) {
+
+    yySequenceParameterTrack.call(this, _pStorage); //base constructor
+    this.m_type = eSTT_AudioEffect;
+    this.m_effectStruct = null;
+
+    if ((_pStorage != null) && (_pStorage != undefined)) {
+        this.m_interpolation = _pStorage.interpolation;
+    }
+
+    Object.defineProperties(this, {
+        gmlinterpolation: {
+            enumerable: true,
+            get: function () { return this.m_interpolation; },
+            set: function (_val)
+            {
+                var val = yyGetInt32(_val);
+                if ((val >= 0) && (val < sRM_Max))
+                {
+                    this.m_interpolation = val;
+                }
+                else
+                {
+                    debug("Trying to set interpolation property of track to out-of-bounds value " + yyGetReal(_val));
+                }                
+            }
+        }
+    });
+
+    this.getCachedChannelVal = function (_channel, _key, _seqlength, _descriptor)
+    {
+        var pRes = null;
+
+        var dirty = false;
+        var force = false;
+        if (_channel >= this.numCachedPoints.length || this.numCachedPoints[_channel] == 0)
+        {
+            force = true;
+        }
+        else if (this.globalChangeIndex < GetCurrSeqObjChangeIndex())
+        {
+            if (this.m_keyframeStore.IsDirty(this.changeIndex))
+            {
+                dirty = true;
+            }
+
+            this.globalChangeIndex = GetCurrSeqObjChangeIndex();
+        }
+
+        if (dirty || force)
+        {
+            // We need to update the cached points for *all* used channels here otherwise when we update changeIndex we lose the ability to detect changes on other channels
+            var maxchan = yymax(this.numCachedPoints.length, _channel + 1);
+            for (var i = 0; i < maxchan; i++)
+            {
+                if ((i >= this.numCachedPoints.length) || (this.numCachedPoints[i] != -1))
+                {
+                    this.UpdateCachedPoints(i, _seqlength);
+                }
+            }
+            this.changeIndex = yymax(this.changeIndex, this.m_keyframeStore.changeIndex);
+        }
+
+        var numpoints = this.numCachedPoints[_channel];
+        if (numpoints == 0)
+        {
+            // _res must contain the default value, or be handled otherwise
+            return null; // no points to be found
+        }
+
+        var pPoints = this.cachedPoints[_channel];
+
+        // TODO: might be worth switching back to linear search in conjunction with keeping track of the index of the start of the pair
+        // of evaluated points we interpolated between - this should make normal playback very cheap (unless we're dealing with
+        // a lot of tightly packed control points).
+
+        // Special-case for end point
+        if (pPoints[numpoints - 1].m_x < _key)
+        {
+            pRes = pPoints[numpoints - 1].m_value;
+            return pRes;
+        }
+
+        // binary search
+        var start, end, mid;
+        start = 0;
+        end = numpoints;
+
+        mid = (start + end) >> 1;
+        while (mid != start)
+        {
+            if (pPoints[mid].m_x > _key)
+            {
+                end = mid;
+            }
+            else
+            {
+                start = mid;
+            }
+
+            mid = (start + end) >> 1;
+        }
+
+        if ((this.m_interpolation == sRM_DirectAssign) || (mid == (numpoints - 1)))
+        {
+            if (pPoints[0].m_x > _key)
+            {
+                pRes = _descriptor.defaultValue;
+            }
+            else
+            {
+                pRes = pPoints[mid].m_value;
+            }
+        }
+        else
+        {
+            let pFirstPoint = pPoints[mid];
+            let pSecondPoint = pPoints[mid + 1];
+    
+            if (pPoints[0].m_x > _key)
+            {
+                pSecondPoint = pFirstPoint;
+
+                pFirstPoint = new yyAnimCurvePoint();
+                pFirstPoint.m_x = 0;
+                pFirstPoint.m_value = _descriptor.defaultValue;
+            }
+    
+            if (_channel == 0)
+            {
+                pRes = pFirstPoint.m_value;
+            }
+            else if ((pSecondPoint.m_x - pFirstPoint.m_x) > 0.0)
+            {
+                const prop = (_key - pFirstPoint.m_x) / (pSecondPoint.m_x - pFirstPoint.m_x);
+    
+                pRes = (pSecondPoint.m_value * prop) + (pFirstPoint.m_value * (1.0 - prop));
+    
+                if (_descriptor.integer)
+                {
+                    pRes = Math.floor(pRes);
+                }
+            }
+            else
+            {
+                pRes = pFirstPoint.m_value;
+            }
+        }
+
+        return pRes;
+    };
+
+    // #############################################################################################
+    /// Function:<summary>
+    ///             Returns the value for a given channel at the given key
+    ///          </summary>
+    // #############################################################################################
+    this.getValue = function (_channel, _key, _seqlength) {
+        const paramDescriptor = this.GetParamDescriptor(_channel);
+
+        if (!this.enabled) return paramDescriptor.defaultValue;
+        if (this.m_keyframeStore == null) return paramDescriptor.defaultValue;
+        if (this.m_keyframeStore.numKeyframes == 0) return paramDescriptor.defaultValue;
+
+        return this.getCachedChannelVal(_channel, _key, _seqlength, paramDescriptor);
+    };
+
+    // #############################################################################################
+    /// Function:<summary>
+    ///             Update the cached points for the given channel
+    ///          </summary>
+    // #############################################################################################
+    this.UpdateCachedPoints = function(_channel, _seqlength) {
+	    // Mirror new IDE length paradigm
+        _seqlength += 1;
+
+        if(_channel > this.numCachedPoints.length)
+        {
+            var oldMaxCachedChannels = this.numCachedPoints.length;
+            this.numCachedPoints.length = _channel + 1;
+
+            // initialise newly added num cached points entries to -1
+            // Setting this to -1 allows us to detect channels which are never actually used
+            for(var i = oldMaxCachedChannels; i < this.numCachedPoints.length; i++)
+            {
+                this.numCachedPoints[i] = -1;
+            }
+        }
+
+        // Reset number of cached points
+        this.numCachedPoints[_channel] = 0;
+
+        // Now step through the keyframe list and add the points to the appropriate cached point list
+        // I'm currently assuming that they'll be in order and no keyframes will overlap
+        for (var i = 0; i < this.m_keyframeStore.numKeyframes; i++)
+        {
+            var key = this.m_keyframeStore.keyframes[i];
+            var value = key.m_channels[_channel];
+            if (value == null) {
+                // Hack (also in IDE);
+                // take the first key then; but we require that this key is an animation curve and that curve contains this channel then
+                value = key.m_channels[0];
+                if ((value == null) || ((value.m_curveIndex == -1) && (value.m_pEmbeddedCurve == null)))
+                    continue;
+            }
+
+            if ((value.m_curveIndex == -1) && (value.m_pEmbeddedCurve == null))
+            {
+                var pPoint = this.AllocNewCachedPoint(_channel);
+                pPoint.m_x = key.m_key;
+                pPoint.m_value = value.m_realValue;
+
+                if (!key.m_stretch && key.m_length > 1)
+                {
+                    var pPoint = this.AllocNewCachedPoint(_channel);
+                    pPoint.m_x = (key.m_key + (key.m_length));
+                    pPoint.m_value = value.m_realValue;
+                }
+                else if (key.m_stretch == true)
+                {
+                    if (i == (this.m_keyframeStore.numKeyframes - 1))
+                    {
+                        // This is the last keyframe, so stretch until the end of the sequence
+                        if ((_seqlength - key.m_key) > 1)
+                        {
+                            var pPoint = this.AllocNewCachedPoint(_channel);
+                            pPoint.m_x = key.m_key + (_seqlength - key.m_key);
+                            pPoint.m_value = value.m_realValue;
+                        }
+                    }
+                    else
+                    {
+                        // Get the next key position and add a new point just before it
+                        var nextkey = this.m_keyframeStore.keyframes[i + 1];
+                        if (nextkey.m_key > (key.m_key + 1))
+                        {
+                            var pPoint = this.AllocNewCachedPoint(_channel);
+                            pPoint.m_x = nextkey.m_key;
+                            pPoint.m_value = value.m_realValue;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var keylength = key.m_length;
+                if (key.m_stretch == true)
+                {
+                    if (i == (this.m_keyframeStore.numKeyframes - 1))
+                    {
+                        // This is the last keyframe, so stretch until the end of the sequence
+                        if (_seqlength <= 0) continue;	// err...
+                        else
+                        {
+                            //keylength = _seqlength - (key->key + 1);
+                            keylength = _seqlength - key.m_key;
+                        }
+                    }
+                    else
+                    {
+                        var nextkey = this.m_keyframeStore.keyframes[i + 1];
+                        if (nextkey.m_key > key.m_key)
+                        {
+                            keylength = nextkey.m_key - key.m_key;
+                        }
+                    }
+                }
+
+                var pCurve = null;
+
+                if (value.m_hasEmbeddedCurve)
+			    {
+			        pCurve = value.m_pEmbeddedCurve;
+			    }
+			    else
+                {
+                    // Try and find curve in the global resource list
+                    pCurve = g_pAnimCurveManager.Get(value.m_curveIndex);
+                }
+
+                if (pCurve == null)
+                {
+                    //dbg_csol.Output("Could not find anim curve.\n");
+                    continue;
+                }
+
+                var curvechannel = _channel;
+                if (curvechannel >= pCurve.m_numChannels)
+                {
+                    curvechannel = pCurve.m_numChannels - 1;
+                }
+
+                // Now add the curve key points
+                pCurve.Evaluate(this, curvechannel, _channel, key.m_key, keylength);
+            }
+        }
+    };
+    
+    //calculate accumulated frames travelled (area under image speed keys) from _startKey to _key
+    //returns true if _res is set
+    this.calculateAnimDistance = function(_channel, _startKey, _key, _seqlength, _res)
+    {
+	    var pRes = null;
+
+	    if (!this.enabled) return null;
+        if (this.m_keyframeStore == null) return null;
+        if (this.m_keyframeStore.numKeyframes == 0) return null;
+
+	    var numpoints = this.numCachedPoints[_channel];
+	    if (numpoints == 0) {
+		    return null; // no points to be found
+	    }
+
+	    //if requested key position is less than start, zero accumulated distance
+	    var relKey = _key - _startKey;
+	    if (relKey <= 0) {
+		    pRes = 0;
+		    return pRes;
+	    }
+
+	    var pPoints = this.cachedPoints[_channel];
+	    var dtotal = 0;
+	    //if there is just a single key, speed is constant across entire track
+	    if (numpoints == 1) {
+		    dtotal = pPoints[0].m_value * relKey;
+		    pRes = dtotal;
+		    return pRes;
+	    }
+
+	    var interpolated = this.m_interpolation == sRM_Lerp;
+	    //velocity is continuous up to the first key-
+	    var p0 = pPoints[0];
+	    var t = yymin(p0.m_x, _key) - _startKey;
+	    if( t > 0 )
+		    dtotal = p0.m_value * t;
+
+	    for (var i = 1; i < numpoints; ++i)
+	    {
+		    if (p0.m_x >= _key)
+			    break;
+
+		    var p1 = pPoints[i];
+		    if (p1.m_x > _startKey)   //ignore this segment if its entirely before the start key
+		    {
+			    t = yymin(p1.m_x, _key) - p0.m_x;
+			    if (t > 0)
+			    {
+				    var d;
+				    var offset = (_startKey - p0.m_x); // distance from p0 to startKey - >0 if start position intersects this segment
+				    if (!interpolated)
+				    {
+					    if (offset > 0) //if start position intersects this segment
+						    t -= offset;
+					    d = p0.m_value * t;
+				    }
+				    else
+				    {
+					    var a = (p1.m_value - p0.m_value) / (p1.m_x - p0.m_x);
+					    var v0 = p0.m_value;
+					    if (offset >0) {//if start position intersects this segment
+						    t -= offset;
+						    v0 += a * offset;
+					    }
+					    d = v0 * t + (0.5 * a * t * t); //v0t +1/2at^2
+				    }
+				    dtotal += d;
+			    }
+		    }
+		    p0 = p1;
+	    }
+	    //add any remainder from last key to requested head - constant v to end of track
+	    var rem = _key - p0.m_x;
+	    if (rem > 0)
+	    {
+		    var d = p0.m_value * (rem);
+		    dtotal += d;
+	    }
+
+	    pRes = yymax(dtotal,0);
+	    return pRes;
+    };
+
+    this.InstantiateEffect = function()
+    {
+        if (this.m_effectStruct === null)
+        {
+            const effectType = this.AudioEffectTypeFromTrackName();
+            this.m_effectStruct = audio_effect_create(effectType);
+            this.m_parent.PushEffectStruct(this.m_effectStruct);
+        }
+
+        return this.m_effectStruct;
+    };
+
+    this.AudioEffectTypeFromTrackName = function()
+    {
+        switch (this.builtinName)
+        {
+            case eT_AudioEffect_Bitcrusher: return AudioEffect.Type.Bitcrusher;
+            case eT_AudioEffect_Compressor: return AudioEffect.Type.Compressor;
+            case eT_AudioEffect_Delay:		return AudioEffect.Type.Delay;
+            case eT_AudioEffect_Gain:		return AudioEffect.Type.Gain;
+            case eT_AudioEffect_Hishelf:	return AudioEffect.Type.HiShelf;
+            case eT_AudioEffect_Hpf2:		return AudioEffect.Type.HPF2;
+            case eT_AudioEffect_Loshelf:	return AudioEffect.Type.LoShelf;
+            case eT_AudioEffect_Lpf2:		return AudioEffect.Type.LPF2;
+            case eT_AudioEffect_PeakEQ:		return AudioEffect.Type.PeakEQ;
+            case eT_AudioEffect_Reverb1:	return AudioEffect.Type.Reverb1;
+            case eT_AudioEffect_Tremolo:	return AudioEffect.Type.Tremolo;
+            default:
+                yyError("Unsupported audio effect track type");
+                return undefined;
+        }
+    };
+
+    this.IsBusTrack = function()
+    {
+        return (this.builtinName == eT_AudioEffect_Bus);
+    }
+
+    this.GetAFXStruct = function() {
+        if (this.IsBusTrack()) {
+            return this.m_parent.m_busStruct;
+        }
+
+        return this.m_effectStruct;
+    };
+
+    this.GetParamDescriptor = function(_channel)
+    {
+        const struct = this.GetAFXStruct();
+        return struct.getParamDescriptor(_channel);
     };
 }
 
@@ -665,9 +1122,9 @@ function yySequenceParameterTrack(_pStorage) {
             // We need to update the cached points for *all* used channels here otherwise when we update changeIndex we lose the ability to detect changes on other channels
             var maxchan = yymax(this.numCachedPoints.length, _channel + 1);
             for (var i = 0; i < maxchan; i++)
-{
+            {
                 if ((i >= this.numCachedPoints.length) || (this.numCachedPoints[i] != -1))
-{
+                {
                     this.UpdateCachedPoints(i, _seqlength);
                 }
             }
@@ -676,7 +1133,7 @@ function yySequenceParameterTrack(_pStorage) {
 
         var numpoints = this.numCachedPoints[_channel];
         if (numpoints == 0)
-{
+        {
             // _res must contain the default value, or be handled otherwise
             return null; // no points to be found
         }
@@ -1119,6 +1576,33 @@ function yySequenceAudioTrack(_pStorage) {
 
     yySequenceBaseTrack.call(this, _pStorage); //base constructor
     this.m_type = eSTT_Audio;
+    this.m_busStruct = null;
+
+    this.InstantiateBus = function()
+    {
+        if (this.m_busStruct === null)
+        {
+            this.m_busStruct = audio_bus_create();
+        }
+
+        return this.m_busStruct;
+    };
+
+    this.PushEffectStruct = function(_effectStruct)
+    {
+        const busStruct = this.InstantiateBus();
+
+        for (let i = AudioBus.NUM_EFFECT_SLOTS - 1; i >= 0; --i)
+        {
+            if (busStruct.proxy[i] == undefined)
+            {
+                busStruct.proxy[i] = _effectStruct;
+                return;
+            }
+        }
+    
+        yyError("Failed to push effect to bus: track is full");
+    };
 }
 
 // #############################################################################################
@@ -1306,6 +1790,7 @@ function yySequenceBaseTrack(_pStorage) {
     this.m_numResources = 0;
     this.m_ownedResources = [];
     this.m_keyframeStore = new yyKeyframeStore();
+    this.m_parent = null;
 
     if ((_pStorage != null) && (_pStorage != undefined)) {
 
@@ -1327,6 +1812,7 @@ function yySequenceBaseTrack(_pStorage) {
         this.m_tracks = [];
         for (var trackIndex = 0; trackIndex < this.m_numTracks; ++trackIndex) {
             this.m_tracks[trackIndex] = SequenceBaseTrack_Load(_pStorage.tracks[this.m_numTracks - 1 - trackIndex]);
+            this.m_tracks[trackIndex].m_parent = this;
         }
 
         this.m_numResources = _pStorage.ownedResourceModels.length;
@@ -1785,6 +2271,47 @@ function yySequenceBaseTrack(_pStorage) {
                                 _result.pFontEffectParams.shadowAlpha = ((evalColor >> 24) & 0xff) / 255.0;
                                 
                                 _result.paramset.SetBit(eT_TextEffect_ShadowColour);
+                            }
+                        }
+                        break;
+                    case eT_AudioEffect_Bus:
+                        if (track.m_type == eSTT_AudioEffect)
+                        {
+                            if (!isCreationTrack || !(_result.paramset.GetBit(eT_AudioEffect_Bus)))
+                            {
+                                const parentTrack = track.m_parent;
+                                const busStruct = parentTrack.InstantiateBus();
+
+                                busStruct.getParamDescriptors().forEach((_desc, _idx) => {
+                                    busStruct["gml" + _desc.name] = track.evaluate(_idx, _head, _length);
+                                });
+                                
+                                _result.paramset.SetBit(eT_AudioEffect_Bus);
+                            }
+                        }
+                        break;
+                    case eT_AudioEffect_Bitcrusher:
+                    case eT_AudioEffect_Compressor:
+                    case eT_AudioEffect_Delay:
+                    case eT_AudioEffect_Gain:
+                    case eT_AudioEffect_Hishelf:
+                    case eT_AudioEffect_Loshelf:
+                    case eT_AudioEffect_PeakEQ:
+                    case eT_AudioEffect_Hpf2:
+                    case eT_AudioEffect_Lpf2:
+                    case eT_AudioEffect_Reverb1:
+                    case eT_AudioEffect_Tremolo:
+                        if (track.m_type == eSTT_AudioEffect)
+                        {
+                            if (!isCreationTrack || !(_result.paramset.GetBit(track.builtinName)))
+                            {
+                                const effectStruct = track.InstantiateEffect();
+
+                                effectStruct.getParamDescriptors().forEach((_desc, _idx) => {
+                                    effectStruct["gml" + _desc.name] = track.evaluate(_idx, _head, _length);
+                                });
+                                
+                                _result.paramset.SetBit(track.builtinName);
                             }
                         }
                         break;
@@ -2422,6 +2949,124 @@ function yyStringTrackKey(_pStorage)
 
 // #############################################################################################
 /// Function:<summary>
+///             Create a new Audio Effect Track Key object
+///          </summary>
+// #############################################################################################
+/** @constructor */
+function yyAudioEffectTrackKey(_pStorage)
+{
+    yyTrackKeyBase.call(this); //base constructor
+
+    this.__type = "[AudioEffectTrackKey]";
+
+    this.m_realValue = 0;
+    this.m_hasEmbeddedCurve = false;
+    this.m_curveIndex = -1;
+    this.m_pEmbeddedCurve = null;
+
+    if ((_pStorage != null) && (_pStorage != undefined)) {
+        this.m_realValue = _pStorage.realValue;
+        this.m_hasEmbeddedCurve = _pStorage.hasEmbeddedCurve;
+        this.m_curveIndex = _pStorage.curveIndex;
+
+        if (_pStorage.pEmbeddedCurve != undefined)
+        {
+            this.m_pEmbeddedCurve = new yyAnimCurve(_pStorage.pEmbeddedCurve);
+        }        
+    }
+
+    this.UpdateDirtiness = function()
+    {
+        var currChangeIndex = this.changeIndex;
+        for(var channel in this.m_channels)
+        {
+            var pCurve = g_pAnimCurveManager.GetCurveFromID(channel.m_curveIndex);
+    
+            if ((pCurve != null) && (pCurve.IsDirty(currChangeIndex)))
+            {
+                this.changeIndex = yymax(this.changeIndex, pCurve.changeIndex);			
+            }
+        }
+    };
+
+    Object.defineProperties(this, {
+        gmlvalue: {
+            enumerable: true,
+            get: function () { return this.m_realValue; },
+            set: function (_val)
+            {
+                this.m_realValue = yyGetReal(_val);
+
+                // Clear curve data
+                this.m_curveIndex = -1;
+                this.m_hasEmbeddedCurve = false;
+                this.m_pEmbeddedCurve = null;
+            }
+        }, 
+        gmlhasEmbeddedCurve: {
+            enumerable: true,
+            get: function () { return this.m_hasEmbeddedCurve; },
+            set: function (_val) { this.m_hasEmbeddedCurve = yyGetBool(_val); }
+        },
+        gmlcurve: {
+            enumerable: true,
+            get: function ()
+            {
+                var tempcurve = undefined;
+                if ((this.m_hasEmbeddedCurve == true) && (this.m_pEmbeddedCurve != null))
+                {
+                    tempcurve = this.m_pEmbeddedCurve;
+                }
+                else
+                {
+                    tempcurve = g_pAnimCurveManager.Get(this.m_curveIndex);                    
+                }
+
+                if ((tempcurve == undefined) || (tempcurve == null))
+                    return -1;
+                else
+                    return tempcurve;
+            },
+            set: function (_val)
+            {
+                if(typeof(_val) == "object")
+                {
+                    var idx = g_pAnimCurveManager.AnimCurves.indexOf(_val);
+                    if (idx == -1)
+                    {
+                        // Embedded curve
+                        this.m_pEmbeddedCurve = _val;
+                        this.m_hasEmbeddedCurve = true;
+                        this.m_curveIndex = -1;
+                    }
+                    else
+                    {
+                        this.m_curveIndex = idx;
+                        this.m_hasEmbeddedCurve = false;
+                        this.m_pEmbeddedCurve = null;
+                    }
+                }
+                else
+                {
+                    // Check for valid index
+                    if(g_pAnimCurveManager.Get(this.m_curveIndex) != null)
+                    {
+                        this.m_curveIndex = _val;
+                        this.m_hasEmbeddedCurve = false;
+                        this.m_pEmbeddedCurve = null;
+                    }
+                    else
+                    {
+                        throw new Error("Invalid curve passed to curve property of keyframe channel");
+                    }
+                }
+            }
+        },     
+    });
+}
+
+// #############################################################################################
+/// Function:<summary>
 ///             Create a new Text Track Key object
 ///          </summary>
 // #############################################################################################
@@ -2588,6 +3233,9 @@ function yyKeyframe(_type, _pStorage) {
                     break;
                 case eSTT_String:
                     newKeyframe = new yyStringTrackKey(data);
+                    break;
+                case eSTT_AudioEffect:
+                    newKeyframe = new yyAudioEffectTrackKey(data);
                     break;
                 case eSTT_Sequence:
                     newKeyframe = new yySequenceTrackKey(data);
@@ -3272,6 +3920,7 @@ function yySequence(_pStorage) {
         this.m_tracks = [];
         for (var trackIndex = 0; trackIndex < this.m_numTracks; ++trackIndex) {
             this.m_tracks[trackIndex] = SequenceBaseTrack_Load(_pStorage.tracks[this.m_numTracks - 1 - trackIndex]);
+            this.m_tracks[trackIndex].m_parent = this;
         }
 
         this.m_numEvents = _pStorage.sequenceEvents.length;
@@ -4962,7 +5611,7 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
             g_SeqStack.push(pAudioKey);
 
             for (var channelKey in pAudioKey.m_channels)
-{
+            {
                 var ppChanKey = pAudioKey.m_channels[channelKey];
 
                 g_SeqStack.push(ppChanKey);
@@ -4978,6 +5627,11 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
                         {
                             audio_stop_sound(pAudioInfo.soundindex);
                             pAudioInfo.soundindex = -1;
+
+                            if (_pTrack.m_busStruct !== null)
+                            {
+                                audio_bus_clear_emitters(_pTrack.m_busStruct);
+                            }
                         }
                     }
                     else
@@ -4989,11 +5643,21 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
                             {
                                 audio_stop_sound(pAudioInfo.soundindex);
                                 pAudioInfo.soundindex = -1;
+
+                                if (_pTrack.m_busStruct !== null)
+								{
+									audio_bus_clear_emitters(_pTrack.m_busStruct);
+								}
                             }
                         }
 
                         if (pAudioInfo.soundindex == -1)
                         {
+                            if (_pTrack.m_busStruct !== null)
+							{
+								audio_emitter_bus(pAudioInfo.emitterindex, _pTrack.m_busStruct);
+							}
+
                             pAudioInfo.playdir = _headDir;
                             pAudioInfo.soundindex = audio_play_sound_on(pAudioInfo.emitterindex, ppChanKey.m_soundIndex, (ppChanKey.m_mode == eSM_Loop) ? true : false, 1.0);
 

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -1022,7 +1022,7 @@ function yySequenceAudioEffectTrack(_pStorage) {
     this.IsBusTrack = function()
     {
         return (this.builtinName == eT_AudioEffect_Bus);
-    }
+    };
 
     this.GetAFXStruct = function() {
         if (this.IsBusTrack()) {

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -1601,8 +1601,27 @@ function yySequenceAudioTrack(_pStorage) {
             }
         }
     
-        yyError("Failed to push effect to bus: track is full");
+        yyError("Failed to push effect to bus. Audio tracks cannot hold more than "
+            + AudioBus.NUM_EFFECT_SLOTS + " audio effect tracks");
     };
+
+    this.UpdateBusLayout = function()
+    {
+        if (this.m_busStruct === null)
+            return;
+
+        const fxStructs = this.m_tracks.filter(_track => _track.m_effectStruct instanceof AudioEffectStruct)
+                                       .map(_track => _track.m_effectStruct);
+        
+        for (let i = 0; i < AudioBus.NUM_EFFECT_SLOTS; ++i)
+        {
+            // Potentially getting undefined elements here is intentional
+            if (fxStructs[i] !== this.m_busStruct.effects[AudioBus.NUM_EFFECT_SLOTS - 1 - i])
+            {
+                this.m_busStruct.proxy[AudioBus.NUM_EFFECT_SLOTS - 1 - i] = fxStructs[i];
+            }
+        }
+    }
 }
 
 // #############################################################################################
@@ -5715,6 +5734,8 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
             g_SeqStack.pop();
         }
     }
+
+    _pTrack.UpdateBusLayout();
 };
 
 

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -1857,6 +1857,7 @@ function yySequenceBaseTrack(_pStorage) {
             {
                 if(_val instanceof Array)
                 {
+                    _val.forEach(_track => { _track.m_parent = this; });
                     this.m_tracks = _val;
                 }
                 else
@@ -4058,6 +4059,7 @@ function yySequence(_pStorage) {
             {
                 if(_val instanceof Array)
                 {
+                    _val.forEach(_track => { _track.m_parent = this; });
                     this.m_tracks = _val;
                 }
                 else


### PR DESCRIPTION
- Adds audio effect parameter tracks.
- Reworks internals of audio effect parameters so that they can be indexed.
- Gives each sequence track a reference to its parent.
- Fixes creation of colour tracks through `sequence_track_new`.
- Fixes a bug with replacing audio nodes in effect chains.

Relates to:
- https://github.com/YoYoGames/GameMaker-Bugs/issues/3162.
- https://github.com/YoYoGames/GameMaker/pull/3389.