### PR TITLE
[HTML5] Fix for draw_text_ext when passed string with no spaces

### DIFF
--- a/scripts/yyFont.js
+++ b/scripts/yyFont.js
@@ -1890,7 +1890,7 @@ yyFontManager.prototype.Split_TextBlock = function (_pStr, linewidth, thefont) {
 							end = e;
 						}
 						else {
-							while(pNew[end]!=whitespace)
+							while(pNew[end]!=whitespace && end<len)
 								end++;
 						}
 


### PR DESCRIPTION
https://github.com/YoYoGames/GameMaker-Bugs/issues/4374