### PR TITLE
audio_destroy_stream return value

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3112,9 +3112,12 @@ function audio_destroy_stream(_soundid)
             audio_stop_sound(_soundid);
             audio_sampledata[_soundid] = null;
         }
+        
+        return 1;
     }
-}
 
+    return -1;
+}
 
 function allocateBufferSound( )
 {

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -109,7 +109,11 @@ function audio_update()
 
     // Update and apply gains
     g_AudioGroups.forEach(_group => _group.gain.update());
-    audio_sampledata.forEach(_asset => _asset.gain.update());
+    audio_sampledata.forEach(_asset => {
+        if (_asset != null) {
+            _asset.gain.update();
+        }
+    });
     audio_sounds.forEach(_voice => _voice.updateGain());
 }
 


### PR DESCRIPTION
- Fixes the return value of `audio_destroy_stream`.
- Adds a check for `null` assets when updating asset gains.
- Fixes https://github.com/YoYoGames/GameMaker-Bugs/issues/4415.