### PR TITLE
GMB-2754: Add new function vertex_submit_ext

### DIFF
--- a/scripts/Builders/yyPrimBuilder.js
+++ b/scripts/Builders/yyPrimBuilder.js
@@ -12,7 +12,7 @@
 
 // @if feature("gl") && (function("draw_primitive_*") || function("draw_vertex*") || function("vertex_*"))
 
-// primitive type translation is shared between draw_primitive_* and vertex_submit
+// primitive type translation is shared between draw_primitive_* and vertex_submit(_ext)
 var PrimType_POINTLIST = 1,
 	PrimType_LINELIST = 2,
 	PrimType_LINESTRIP	= 3,

--- a/scripts/Builders/yyVBufferBuilder.js
+++ b/scripts/Builders/yyVBufferBuilder.js
@@ -369,6 +369,10 @@ function yyVBufferBuilder(_size) {
             vertexCount = m_vertexCount - _offset;
         }
 
+        if (vertexCount <= 0) {
+            return;
+        }
+
         if (m_frozen) {
 
             // Directly submit the vertex buffer

--- a/scripts/Builders/yyVBufferBuilder.js
+++ b/scripts/Builders/yyVBufferBuilder.js
@@ -355,14 +355,27 @@ function yyVBufferBuilder(_size) {
     ///          </summary>
     // #############################################################################################
     /** @this {yyVBufferBuilder} */	
-    this.Submit = function(_primType, _texture) {
+    this.Submit = function(_primType, _texture, _offset, _number) {
+        if (_offset === undefined) _offset = 0;
+        if (_number === undefined) _number = -1;
+
+        if (_offset < 0) {
+            yyError("vertex_submit_ext: offset cannot be a negative number!");
+            return;
+        }
+
+        var vertexCount = (_number < 0) ? m_vertexCount : _number;
+        if (_offset + vertexCount > m_vertexCount) {
+            vertexCount = m_vertexCount - _offset;
+        }
+
         if (m_frozen) {
 
             // Directly submit the vertex buffer
             // (I don't believe a flush is necessary as it shouldn't affect
             // the building up of the current in-flight vertex buffer)
             if (_texture == -1) {
-                g_webGL.DispatchVBuffer(_primType,null, m_VBuffer, 0);
+                g_webGL.DispatchVBuffer(_primType,null, m_VBuffer, _offset, vertexCount);
             }
             else {
                 // Check whether the webgl texture has been initialised yet and do so if not
@@ -373,13 +386,13 @@ function yyVBufferBuilder(_size) {
                         return;
                     }
                 }
-                g_webGL.DispatchVBuffer(_primType, _texture.WebGLTexture.webgl_textureid, m_VBuffer, 0);
+                g_webGL.DispatchVBuffer(_primType, _texture.WebGLTexture.webgl_textureid, m_VBuffer, _offset, vertexCount);
             }
         }
         else {
             var pBuff;
             if (_texture == -1) {
-                pBuff = g_webGL.AllocVerts(_primType, null, m_FVF, m_vertexCount);
+                pBuff = g_webGL.AllocVerts(_primType, null, m_FVF, vertexCount);
             } else {
                 // Check whether the webgl texture has been initialised yet and do so if not
                 if (_texture && !_texture.WebGLTexture.webgl_textureid) {
@@ -389,18 +402,18 @@ function yyVBufferBuilder(_size) {
                         return;
                     }
                 }
-                pBuff = g_webGL.AllocVerts(_primType, _texture.WebGLTexture.webgl_textureid, m_FVF, m_vertexCount);
+                pBuff = g_webGL.AllocVerts(_primType, _texture.WebGLTexture.webgl_textureid, m_FVF, vertexCount);
             }
 
             // Get the data across
             var currpos = pBuff.Current * m_vertexFormat.ByteSize;
 
             // Open a data view onto the vertex array to allow for easy copying to the VBuffer vertex data store
-            var vertexDataView = new Int8Array(m_arrayBuffer, 0, m_vertexCount * m_vertexFormat.ByteSize);
+            var vertexDataView = new Int8Array(m_arrayBuffer, _offset * m_vertexFormat.ByteSize, vertexCount * m_vertexFormat.ByteSize);
 
             // This buffer copy might seem a bit unnecessary but it's there so that the vertex buffer can be reused
             pBuff.VertexData.set(vertexDataView, currpos);
-            pBuff.Current += m_vertexCount;
+            pBuff.Current += vertexCount;
         }
     };
 

--- a/scripts/libWebGL/libWebGL.js
+++ b/scripts/libWebGL/libWebGL.js
@@ -2103,10 +2103,10 @@ function yyWebGL(_canvas, _options) {
     ///          </summary>
     // #############################################################################################
     /** @this {yyWebGL} */
-    this.DispatchVBuffer = function (_prim, _texture, _vbuffer, _vertexStart) {
+    this.DispatchVBuffer = function (_prim, _texture, _vbuffer, _vertexStart, _vertexCount) {
     
         yyGL.REQUIRE((_texture == null) || (_texture instanceof yyGLTexture), "Texture is not a yyGLTexture", yyGL.ERRORLEVEL_Development);        
-        m_VBufferManager.Dispatch(_prim, _texture, _vbuffer, _vertexStart);
+        m_VBufferManager.Dispatch(_prim, _texture, _vbuffer, _vertexStart, _vertexCount);
     };
 
 

--- a/scripts/libWebGL/yyVBufferManager.js
+++ b/scripts/libWebGL/yyVBufferManager.js
@@ -51,9 +51,11 @@ function yyVBufferManager(_commandBuilder,_renderStateManager) {
     ///          </summary>
     // #############################################################################################
     /** @this {yyVBufferManager} */
-    this.Dispatch = function (_prim, _texture, _vbuffer, _vertexStart) {
+    this.Dispatch = function (_prim, _texture, _vbuffer, _vertexStart, _vertexCount) {
+		var size = (_vertexCount === undefined)
+			? _vbuffer.Current - _vertexStart
+			: _vertexCount;
 
-        var size = _vbuffer.Current - _vertexStart;
         switch (_prim)
     	{
     		case yyGL.PRIM_TRIANGLE:

--- a/scripts/yyBufferVertex.js
+++ b/scripts/yyBufferVertex.js
@@ -39,6 +39,7 @@ var vertex_create_buffer,
     vertex_ubyte4,
     vertex_freeze,
     vertex_submit,
+    vertex_submit_ext,
     vertex_get_number,
     vertex_get_buffer_size,
     vertex_create_buffer_from_buffer,
@@ -70,6 +71,7 @@ var vertex_create_buffer,
     vertex_ubyte4 = _stub("vertex_ubyte4");
     vertex_freeze = _stub("vertex_freeze");
     vertex_submit = _stub("vertex_submit");
+    vertex_submit_ext = _stub("vertex_submit_ext");
     vertex_get_number = _stub("vertex_get_number");
     vertex_get_buffer_size = _stub("vertex_get_buffer_size");
     vertex_create_buffer_from_buffer = _stub("vertex_create_buffer_from_buffer", -1);
@@ -117,6 +119,7 @@ function InitBufferVertexFunctions() {
     vertex_ubyte4 = WebGL_vertex_ubyte4_RELEASE;
     vertex_freeze = WebGL_vertex_freeze_RELEASE;
     vertex_submit = WebGL_vertex_submit_RELEASE;
+    vertex_submit_ext = WebGL_vertex_submit_ext_RELEASE;
     vertex_get_number = WebGL_vertex_get_number_RELEASE;
     vertex_get_buffer_size = WebGL_vertex_get_buffer_size_RELEASE;
     draw_flush = WebGL_draw_flush_RELEASE;
@@ -704,6 +707,34 @@ function WebGL_vertex_submit_RELEASE(_buffer, _primType, _texture)
         }
    
         vertexBuffer.Submit(WebGL_translate_primitive_builder_type(yyGetInt32(_primType)), _texture);
+    }
+}
+
+// #############################################################################################
+/// Function:<summary>
+///             Draw a portion of a vertex buffer
+///          </summary>
+/// In:		<param name="_buffer">Buffer to get count of</param>
+/// In:		<param name="_primType">Type of primitive to render with</param>
+/// In:		<param name="_texture">Texture handle to draw with, or -1 for FLAT</param>
+/// In:		<param name="_offset">The index of the first vertex.</param>
+/// In:		<param name="_number">Number of vertices to draw.</param>
+// #############################################################################################
+function WebGL_vertex_submit_ext_RELEASE(_buffer, _primType, _texture, _offset, _number)
+{
+    g_webGL.Flush();
+    var prim, vertexBuffer = g_vertexBuffers[yyGetInt32(_buffer)];
+    if (vertexBuffer) {
+
+        if (g_CurrentShader != -1) {
+            var shader = g_shaderPrograms[g_CurrentShader].program;
+            var pVertexFormat = vertexBuffer.GetFormat();
+            if (pVertexFormat.Format.length < shader.AttribIndices.length) {
+                ErrorOnce("Trying to use a vertex buffer with too few inputs for the seleted shader.");
+            }
+        }
+   
+        vertexBuffer.Submit(WebGL_translate_primitive_builder_type(yyGetInt32(_primType)), _texture, yyGetInt32(_offset), yyGetInt32(_number));
     }
 }
 


### PR DESCRIPTION
Added new function `vertex_submit_ext(buffer, primtype, texture, offset, number)`, which submits a portion of a vertex buffer. `offset` is the index of the first vertex (cannot be a negative number). `number` is number of vertices to draw. Use -1 to draw all vertices after the starting vertex.

Issue link: https://github.com/YoYoGames/GameMaker-Bugs/issues/2754
