### PR TITLE
Web archive link to the rng paper

### DIFF
--- a/scripts/functions/Function_Maths.js
+++ b/scripts/functions/Function_Maths.js
@@ -453,7 +453,7 @@ function random_use_old_version(_true_false) {
 // #############################################################################################
 /// Function:<summary>
 ///          	Returns a random number between 0 and 1
-///             PRNG from http://www.lomont.org/Math/Papers/2008/Lomont_PRNG_2008.pdf
+///             PRNG from https://web.archive.org/web/20160303224645/http://www.lomont.org/Math/Papers/2008/Lomont_PRNG_2008.pdf
 ///             other reading http://stackoverflow.com/questions/1046714/what-is-a-good-random-number-generator-for-a-game
 ///          </summary>
 // #############################################################################################


### PR DESCRIPTION
The original link in the comment to [the paper about the RNG](https://web.archive.org/web/20160303224645/http://www.lomont.org/Math/Papers/2008/Lomont_PRNG_2008.pdf) 404s after the site it lived on was reorganized a few years ago. I've changed the link to a copy on the Web Archive, which should stay where it is for a while.