### PR TITLE
Fixed crash on switch browser tabs

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -771,8 +771,10 @@ audioSound.prototype.getPlaybackPosition = function(_contextTime) {
             playbackPosition += timePassed;
         }
         else {
+            playbackPosition = loopStart + (timePassed - timeToLoopStart);
             const loopLength = this.getLoopLength();
-            playbackPosition = loopStart + (timePassed - timeToLoopStart) % loopLength;
+            if (loopLength !== 0)
+                playbackPosition %= loopLength;
         }
     }
 


### PR DESCRIPTION
Sometimes runtime write NaN to `audioSound.playbackCheckpoint `:

```
this.playbackCheckpoint = {
    contextTime: contextTime,
    bufferTime: this.getPlaybackPosition(contextTime) // NaN
};
```

After user switch to game page calls:
 - `audioSound.resume` 
 - `audioSound.start(NaN)`
 - `this.pbuffersource.start(0, NaN)` 

```
Unhandled Exception - Uncaught TypeError: Failed to execute 'start' on 'AudioBufferSourceNode': The provided double value is non-finite.
```