### PR TITLE
Fixes bug on `layer_background_index` function

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -2588,7 +2588,7 @@ function layer_background_index( arg1,arg2)
     if (el != null)
     {
         var image_index = yyGetInt32(arg2);
-        var max_index = sprite_get_number(el.m_pBackground.image_index);
+        var max_index = sprite_get_number(el.m_pBackground.index);
 
         el.m_pBackground.image_index = fwrap(image_index, max_index);
     }


### PR DESCRIPTION
The function was not correctly retrieving the max number of indices of the background sprite.

References: https://github.com/YoYoGames/GameMaker-Bugs/issues/4580