### PR TITLE
Invalid audio asset indices

### DIFF
--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -161,7 +161,7 @@ function yyUnhandledExceptionHandler( event )
         let error = event.error; 
 
         // Construct a GML struct to encapsulate the error details.
-        let errorStruct = { } 
+        let errorStruct = { };
         errorStruct.__type = "___struct___"; 
         errorStruct.__yyIsGMLObject = true; 
 

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -1181,32 +1181,22 @@ function getFreeVoice(_props)
 	return null;
 }
 
-function Audio_GetSound(soundid)
-{
-	var pSound = null;
-	if(soundid>=0 && soundid<=audio_sampledata.length )
-	{
-		pSound = audio_sampledata[soundid];
-	}
-	else
-	{
-		var bufferSoundId = soundid - BASE_BUFFER_SOUND_INDEX;
-		if( bufferSoundId >=0 && bufferSoundId < g_bufferSoundCount)
-		{
-				pSound = buffer_sampledata[bufferSoundId];
-		}
-		else
-		{
-			var queueSoundId = soundid - BASE_QUEUE_SOUND_INDEX;
+function Audio_GetSound(soundid) {
+    if (soundid >= 0 && soundid < audio_sampledata.length) {
+        return audio_sampledata[soundid];
+    }
 
-			if (queueSoundId >= 0 && queueSoundId < g_queueSoundCount)
-			{
-				pSound = queue_sampledata[queueSoundId];
-			}
-		}
-	}
+    const bufferSoundId = soundid - BASE_BUFFER_SOUND_INDEX;
+    if (bufferSoundId >= 0 && bufferSoundId < g_bufferSoundCount) {
+            return buffer_sampledata[bufferSoundId];
+    }
 
-	return pSound;
+    const queueSoundId = soundid - BASE_QUEUE_SOUND_INDEX;
+    if (queueSoundId >= 0 && queueSoundId < g_queueSoundCount) {
+        return queue_sampledata[queueSoundId];
+    }
+
+    return null;
 }
 
 function Audio_GetEmitterOrThrow(_emitterIndex) {

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -1509,8 +1509,9 @@ function audio_sound_get_gain(_index)
     else {
         const asset = Audio_GetSound(_index);
 
-        if (asset !== undefined)
+        if (asset !== null) {
             return asset.gain.get();
+        }
     }
 
     return 0;
@@ -1643,8 +1644,7 @@ function audio_sound_get_track_position(_soundid)
 	{
 	    const sound_asset = Audio_GetSound(_soundid);
 
-	    if (sound_asset != undefined)
-	    {
+	    if (sound_asset !== null) {
 	        return sound_asset.trackPos;
 	    }
 	}
@@ -1678,8 +1678,7 @@ function audio_sound_set_track_position(_soundid, _time)
 	    {
 	        const sampleData = Audio_GetSound(_soundid);
 
-	        if (sampleData != undefined)
-	        {
+	        if (sampleData !== null) {
 	            sampleData.trackPos = _time;
 	        }
 	    }


### PR DESCRIPTION
- Fixed `audio_sound_get_gain`, `audio_sound_get_track_position` and `audio_sound_set_track_position` checking retrieved sound assets against `undefined` rather than `null`.
- Fixed an incorrect bounding conditional issue in `Audio_GetSound`.
- Cleaned up `Audio_GetSound`.
- Fixed an obfuscation issue in `yyUnhandledExceptionHandler`, which would only appear if the pretty print option was turned off.
- Fixes https://github.com/YoYoGames/GameMaker-Bugs/issues/4416.
