### PR TITLE
fixed room_get_info

### DIFF
--- a/scripts/functions/Function_Room.js
+++ b/scripts/functions/Function_Room.js
@@ -128,7 +128,7 @@ function room_get_info(_ind, _views, _instances, _layers, _layer_elements, _tile
                 var sourceInstance = pStorage.pInstances[i];
                 if (sourceInstance) 
                 {
-                    var pObj = g_pObjectManager.Get(yyGetInt32(_ind));
+                    var pObj = g_pObjectManager.Get(yyGetInt32(sourceInstance.index));
                     var inst = {};
                     inst.__yyIsGMLObject = true;
                     variable_struct_set(inst, "x", sourceInstance.x ? sourceInstance.x : 0);


### PR DESCRIPTION
room_get_info was using a non-existent variable for getting object index from pInstances
here is the debug console showing the correct "index" variable in an object inside on web runtime:
![image](https://github.com/YoYoGames/GameMaker-HTML5/assets/24947167/cf131083-fcf5-4c97-a931-456c83f67e60)

