### PR TITLE
AudioBus compatibility for Safari version < 15

### DIFF
--- a/scripts/sound/AudioBus.js
+++ b/scripts/sound/AudioBus.js
@@ -85,7 +85,7 @@ AudioBus.prototype.findNextNode = function(_idx)
 AudioBus.prototype.findPrevNode = function(_idx) 
 {
 	const nodes = this.nodes.slice(0, _idx);
-	const prevNode = nodes.findLast((_node) => _node !== undefined);
+	const prevNode = nodes.slice().reverse().find((_node) => _node !== undefined);
 
 	return (prevNode !== undefined) ? prevNode.output : this.inputNode;
 };


### PR DESCRIPTION
I don't know what GameMaker's policy is for backwards compatibility but I was getting this issue with users on Safari 14.x.x as it has no compatibility for the Array.findLast function (any Safari version from before 2021)