### PR TITLE
GMFR-581: Depth-stencil functions

### DIFF
--- a/scripts/Globals.js
+++ b/scripts/Globals.js
@@ -889,9 +889,12 @@ Audio_WebAudio=1,
 	g_pProjection =null,
 	g_pView =null,
 	g_CurrentFrameBuffer =null,
+	g_CurrentDepthBuffer =null,
 	g_CurrentSurfaceId =-1, // for surface_get_target
+	g_CurrentDepthId =-1,
 
 	g_CurrentSurfaceIdStack =[], // ditto
+	g_CurrentDepthIdStack =[],
 
 	g_gmlConst =null,
 	g_AudioBusMain = null;
@@ -1238,6 +1241,7 @@ function    InitAboyneGlobals() {
     g_DialogActive = false;
 
     g_CurrentFrameBuffer =
+    g_CurrentDepthBuffer =
     g_LastEventpObject = null;
 
     g_LastEvent =

--- a/scripts/functions/Function_D3D.js
+++ b/scripts/functions/Function_D3D.js
@@ -305,6 +305,14 @@ function InitD3DFunctions() {
     // rest of the matrix functions are already assigned
 
     // GPU functions
+    compile_if_used(gpu_set_stencil_enable = WebGL_gpu_set_stencil_enable);
+    compile_if_used(gpu_set_stencil_func = WebGL_gpu_set_stencil_func);
+    compile_if_used(gpu_set_stencil_ref = WebGL_gpu_set_stencil_ref);
+    compile_if_used(gpu_set_stencil_read_mask = WebGL_gpu_set_stencil_read_mask);
+    compile_if_used(gpu_set_stencil_write_mask = WebGL_gpu_set_stencil_write_mask);
+    compile_if_used(gpu_set_stencil_fail = WebGL_gpu_set_stencil_fail);
+    compile_if_used(gpu_set_stencil_depth_fail = WebGL_gpu_set_stencil_depth_fail);
+    compile_if_used(gpu_set_stencil_pass = WebGL_gpu_set_stencil_pass);
     compile_if_used(gpu_set_blendmode = WebGL_gpu_set_blendmode);
     compile_if_used(gpu_set_blendenable = WebGL_gpu_set_blendenable);
     compile_if_used(gpu_set_ztestenable = WebGL_gpu_set_ztestenable);
@@ -342,6 +350,14 @@ function InitD3DFunctions() {
     compile_if_used(gpu_set_tex_mip_enable = WebGL_gpu_set_tex_mip_enable);
     compile_if_used(gpu_set_tex_mip_enable_ext = WebGL_gpu_set_tex_mip_enable_ext);
 
+    compile_if_used(gpu_get_stencil_enable = WebGL_gpu_get_stencil_enable);
+    compile_if_used(gpu_get_stencil_func = WebGL_gpu_get_stencil_func);
+    compile_if_used(gpu_get_stencil_ref = WebGL_gpu_get_stencil_ref);
+    compile_if_used(gpu_get_stencil_read_mask = WebGL_gpu_get_stencil_read_mask);
+    compile_if_used(gpu_get_stencil_write_mask = WebGL_gpu_get_stencil_write_mask);
+    compile_if_used(gpu_get_stencil_fail = WebGL_gpu_get_stencil_fail);
+    compile_if_used(gpu_get_stencil_depth_fail = WebGL_gpu_get_stencil_depth_fail);
+    compile_if_used(gpu_get_stencil_pass = WebGL_gpu_get_stencil_pass);
     compile_if_used(gpu_get_blendenable = WebGL_gpu_get_blendenable);
     gpu_get_ztestenable = WebGL_gpu_get_ztestenable;
     compile_if_used(gpu_get_depth = WebGL_gpu_get_depth);

--- a/scripts/functions/Function_D3D.js
+++ b/scripts/functions/Function_D3D.js
@@ -30,6 +30,14 @@ function d3d_set_perspective(){}
 function matrix_get(){}
 function matrix_set(){}
 
+function gpu_set_stencil_enable(){}
+function gpu_set_stencil_func(){}
+function gpu_set_stencil_ref(){}
+function gpu_set_stencil_read_mask(){}
+function gpu_set_stencil_write_mask(){}
+function gpu_set_stencil_fail(){}
+function gpu_set_stencil_depth_fail(){}
+function gpu_set_stencil_pass(){}
 function gpu_set_blendenable(){}
 function gpu_set_ztestenable(){}
 function gpu_set_zfunc(){}
@@ -65,6 +73,14 @@ function gpu_set_tex_max_aniso_ext(){}
 function gpu_set_tex_mip_enable(){}
 function gpu_set_tex_mip_enable_ext(){}
 
+function gpu_get_stencil_enable(){}
+function gpu_get_stencil_func(){}
+function gpu_get_stencil_ref(){}
+function gpu_get_stencil_read_mask(){}
+function gpu_get_stencil_write_mask(){}
+function gpu_get_stencil_fail(){}
+function gpu_get_stencil_depth_fail(){}
+function gpu_get_stencil_pass(){}
 function gpu_get_blendenable(){}
 function gpu_get_ztestenable(){}
 function gpu_get_zfunc(){}
@@ -131,6 +147,14 @@ function gpu_set_state(){}
     compile_if_used(matrix_get = _stub("matrix_get"));
     compile_if_used(matrix_set = _stub("matrix_set"));
     
+    compile_if_used(gpu_set_stencil_enable = _stub("gpu_set_stencil_enable"));
+    compile_if_used(gpu_set_stencil_func = _stub("gpu_set_stencil_func"));
+    compile_if_used(gpu_set_stencil_ref = _stub("gpu_set_stencil_ref"));
+    compile_if_used(gpu_set_stencil_read_mask = _stub("gpu_set_stencil_read_mask"));
+    compile_if_used(gpu_set_stencil_write_mask = _stub("gpu_set_stencil_write_mask"));
+    compile_if_used(gpu_set_stencil_fail = _stub("gpu_set_stencil_fail"));
+    compile_if_used(gpu_set_stencil_depth_fail = _stub("gpu_set_stencil_depth_fail"));
+    compile_if_used(gpu_set_stencil_pass = _stub("gpu_set_stencil_pass"));
     compile_if_used(gpu_set_blendenable = _stub("gpu_set_blendenable"));
     compile_if_used(gpu_set_ztestenable = _stub("gpu_set_ztestenable"));
     compile_if_used(gpu_set_zfunc = _stub("gpu_set_zfunc"));
@@ -165,7 +189,15 @@ function gpu_set_state(){}
     compile_if_used(gpu_set_tex_max_aniso_ext = _stub("gpu_set_tex_max_aniso_ext"));
     compile_if_used(gpu_set_tex_mip_enable = _stub("gpu_set_tex_mip_enable"));
     compile_if_used(gpu_set_tex_mip_enable_ext = _stub("gpu_set_tex_mip_enable_ext"));
-    
+
+    compile_if_used(gpu_get_stencil_enable = _stub("gpu_get_stencil_enable"));
+    compile_if_used(gpu_get_stencil_func = _stub("gpu_get_stencil_func"));
+    compile_if_used(gpu_get_stencil_ref = _stub("gpu_get_stencil_ref"));
+    compile_if_used(gpu_get_stencil_read_mask = _stub("gpu_get_stencil_read_mask"));
+    compile_if_used(gpu_get_stencil_write_mask = _stub("gpu_get_stencil_write_mask"));
+    compile_if_used(gpu_get_stencil_fail = _stub("gpu_get_stencil_fail"));
+    compile_if_used(gpu_get_stencil_depth_fail = _stub("gpu_get_stencil_depth_fail"));
+    compile_if_used(gpu_get_stencil_pass = _stub("gpu_get_stencil_pass"));
     compile_if_used(gpu_get_blendenable = _stub("gpu_get_blendenable"));
     gpu_get_ztestenable = _stub("gpu_get_ztestenable"); // used in a few places
     compile_if_used(gpu_get_zfunc = _stub("gpu_get_zfunc"));
@@ -914,6 +946,46 @@ function WebGL_matrix_stack_is_empty()
         return false;
 }
 
+function WebGL_gpu_set_stencil_enable(_enable)
+{
+    g_webGL.RSMan.SetRenderState(yyGL.RenderState_StencilEnable, yyGetInt32(_enable) >= 0.5);
+}
+
+function WebGL_gpu_set_stencil_func(_cmp_func)
+{
+    g_webGL.RSMan.SetRenderState(yyGL.RenderState_StencilFunc, yyGetInt32(_cmp_func));
+}
+
+function WebGL_gpu_set_stencil_ref(_ref)
+{
+    g_webGL.RSMan.SetRenderState(yyGL.RenderState_StencilRef, yyGetInt32(_ref));
+}
+
+function WebGL_gpu_set_stencil_read_mask(_mask)
+{
+    g_webGL.RSMan.SetRenderState(yyGL.RenderState_StencilMask, yyGetInt32(_mask));
+}
+
+function WebGL_gpu_set_stencil_write_mask(_mask)
+{
+    g_webGL.RSMan.SetRenderState(yyGL.RenderState_StencilWriteMask, yyGetInt32(_mask));
+}
+
+function WebGL_gpu_set_stencil_fail(_stencil_op)
+{
+    g_webGL.RSMan.SetRenderState(yyGL.RenderState_StencilFail, yyGetInt32(_stencil_op));
+}
+
+function WebGL_gpu_set_stencil_depth_fail(_stencil_op)
+{
+    g_webGL.RSMan.SetRenderState(yyGL.RenderState_StencilZFail, yyGetInt32(_stencil_op));
+}
+
+function WebGL_gpu_set_stencil_pass(_stencil_op)
+{
+    g_webGL.RSMan.SetRenderState(yyGL.RenderState_StencilPass, yyGetInt32(_stencil_op));
+}
+
 function WebGL_gpu_set_blendenable(_enable)
 { 
     g_webGL.RSMan.SetRenderState(yyGL.RenderState_AlphaBlendEnable, yyGetInt32(_enable) >= 0.5);
@@ -1356,6 +1428,46 @@ function WebGL_gpu_set_tex_mip_enable_ext(_sampler_index, _enable)
     g_webGL.RSMan.SetSamplerState(stage, yyGL.SamplerState_MipEnable, enable);
 }
 
+function WebGL_gpu_get_stencil_enable()
+{
+    return g_webGL.RSMan.GetRenderState(yyGL.RenderState_StencilEnable) ? 1.0 : 0.0;
+}
+
+function WebGL_gpu_get_stencil_func()
+{
+    return g_webGL.RSMan.GetRenderState(yyGL.RenderState_StencilFunc);
+}
+
+function WebGL_gpu_get_stencil_ref()
+{
+    return g_webGL.RSMan.GetRenderState(yyGL.RenderState_StencilRef);
+}
+
+function WebGL_gpu_get_stencil_read_mask()
+{
+    return g_webGL.RSMan.GetRenderState(yyGL.RenderState_StencilMask);
+}
+
+function WebGL_gpu_get_stencil_write_mask()
+{
+    return g_webGL.RSMan.GetRenderState(yyGL.RenderState_StencilWriteMask);
+}
+
+function WebGL_gpu_get_stencil_fail()
+{
+    return g_webGL.RSMan.GetRenderState(yyGL.RenderState_StencilFail);
+}
+
+function WebGL_gpu_get_stencil_depth_fail()
+{
+    return g_webGL.RSMan.GetRenderState(yyGL.RenderState_StencilZFail);
+}
+
+function WebGL_gpu_get_stencil_pass()
+{
+    return g_webGL.RSMan.GetRenderState(yyGL.RenderState_StencilPass);
+}
+
 function WebGL_gpu_get_blendenable()
 {
     return g_webGL.RSMan.GetRenderState(yyGL.RenderState_AlphaBlendEnable) ? 1.0 : 0.0;
@@ -1660,7 +1772,15 @@ function InitSaveRenderStates()
             "colorwriteenable", yyGL.RenderState_ColourWriteEnable,
             "alphatestenable", yyGL.RenderState_AlphaTestEnable,	
             "alphatestref", yyGL.RenderState_AlphaRef,
-            "alphatestfunc", yyGL.RenderState_AlphaFunc    
+            "alphatestfunc", yyGL.RenderState_AlphaFunc,
+            "stencilenable", yyGL.RenderState_StencilEnable,
+            "stencilfunc", yyGL.RenderState_StencilFunc,
+            "stencilref", yyGL.RenderState_StencilRef,
+            "stencilreadmask", yyGL.RenderState_StencilMask,
+            "stencilwritemask", yyGL.RenderState_StencilWriteMask,
+            "stencilfail", yyGL.RenderState_StencilFail,
+            "stencilzfail", yyGL.RenderState_StencilZFail,
+            "stencilpass", yyGL.RenderState_StencilPass,
         ];
     }
 }

--- a/scripts/functions/Function_Surface.js
+++ b/scripts/functions/Function_Surface.js
@@ -102,6 +102,9 @@ function surface_has_depth(_id)
     if (g_webGL)
     {
         var pSurf = g_Surfaces.Get(_id);
+        if (!g_SupportDepthTexture) {
+            return (pSurf.FrameBufferData.RenderBuffer != null);
+        }
         return (pSurf.textureDepth != null
             && pSurf.textureDepth.webgl_textureid instanceof yyGLTexture);
     }
@@ -378,7 +381,7 @@ function surface_get_texture(_id)
 function surface_get_texture_depth(_id)
 {
     var pSurf = g_Surfaces.Get(yyGetInt32(_id));
-    if (pSurf != null)
+    if (pSurf != null && g_SupportDepthTexture)
     {
         return { WebGLTexture: pSurf.textureDepth, TPE: pSurf.m_pTPE };
     }
@@ -462,8 +465,10 @@ function surface_set_target_system_RELEASE(_id, _depth_id)
 
         if (g_webGL) {
             g_CurrentFrameBuffer = pSurf.FrameBuffer;
-            g_CurrentDepthBuffer = pSurfDepth.textureDepth.webgl_textureid.Texture;
-            g_webGL.SetRenderTarget(pSurf.FrameBuffer, pSurfDepth.textureDepth.webgl_textureid.Texture);
+            g_CurrentDepthBuffer = g_SupportDepthTexture
+                ? pSurfDepth.textureDepth.webgl_textureid.Texture
+                : pSurfDepth.FrameBufferData.RenderBuffer;
+            g_webGL.SetRenderTarget(g_CurrentFrameBuffer, g_CurrentDepthBuffer);
             g_RenderTargetActive = -1;
         } else {
             g_CurrentGraphics = pSurf.graphics;
@@ -566,8 +571,10 @@ function surface_set_target_RELEASE(_id, _depth_id)
 
     if (g_webGL) {
         g_CurrentFrameBuffer = pSurf.FrameBuffer;
-        g_CurrentDepthBuffer = pSurfDepth.textureDepth.webgl_textureid.Texture;
-        g_webGL.SetRenderTarget(pSurf.FrameBuffer, pSurfDepth.textureDepth.webgl_textureid.Texture);
+        g_CurrentDepthBuffer = g_SupportDepthTexture
+            ? pSurfDepth.textureDepth.webgl_textureid.Texture
+            : pSurfDepth.FrameBufferData.RenderBuffer;
+        g_webGL.SetRenderTarget(g_CurrentFrameBuffer, g_CurrentDepthBuffer);
         g_RenderTargetActive = -1;
     } else {
         g_CurrentGraphics = pSurf.graphics;

--- a/scripts/functions/Function_Surface.js
+++ b/scripts/functions/Function_Surface.js
@@ -89,6 +89,10 @@ function surface_get_depth_disable()
     return g_createsurfacedepthbuffers ? false : true;
 }
 
+function surface_has_depth(_id)
+{
+    return true;
+}
 
 // #############################################################################################
 /// Function:<summary>

--- a/scripts/libWebGL/libWebGL.js
+++ b/scripts/libWebGL/libWebGL.js
@@ -1426,7 +1426,7 @@ function yyWebGL(_canvas, _options) {
             bits |= gl.STENCIL_BUFFER_BIT;
         }
         _clearCol = (_clearCol !== undefined) ? _clearCol : 0;
-        _clearDepth = (_clearDepth !== undefined) ? _clearDepth : 0;
+        _clearDepth = (_clearDepth !== undefined) ? _clearDepth : 1.0;
         _clearStencil = (_clearStencil !== undefined) ? _clearStencil : 0;
         m_CommandBuilder.ClearScreen(bits, _clearCol, _clearDepth, _clearStencil);
     };

--- a/scripts/libWebGL/libWebGL.js
+++ b/scripts/libWebGL/libWebGL.js
@@ -1405,9 +1405,15 @@ function yyWebGL(_canvas, _options) {
     /// Function:<summary>
     ///				Clear the region in the indicated color
     ///          </summary>
+    /// In:		<param name="_colour">Whether to clear colour (true/false).</param>
+    /// 		<param name="_depth">Whether to clear the depth buffer (true/false).</param>
+    /// 		<param name="_stencil">Whether to clear the stencil buffer (true/false).</param>
+    /// 		<param name="_clearCol">The clear color. Can be undefined if _colour is false.</param>
+    /// 		<param name="_clearDepth">The clear depth value. Can be undefined if _depth is false.</param>
+    /// 		<param name="_clearStencil">The clear stencil value. Can be undefined if _stencil is false.</param>
     // #############################################################################################
     /** @this {yyWebGL} */
-    this.ClearScreen = function (_colour, _depth, _stencil, _col) {
+    this.ClearScreen = function (_colour, _depth, _stencil, _clearCol, _clearDepth, _clearStencil) {
     
         var bits = 0;
         if (_colour) {
@@ -1419,7 +1425,10 @@ function yyWebGL(_canvas, _options) {
         if (_stencil) {
             bits |= gl.STENCIL_BUFFER_BIT;
         }
-	    m_CommandBuilder.ClearScreen(bits, _col);
+        _clearCol = (_clearCol !== undefined) ? _clearCol : 0;
+        _clearDepth = (_clearDepth !== undefined) ? _clearDepth : 0;
+        _clearStencil = (_clearStencil !== undefined) ? _clearStencil : 0;
+        m_CommandBuilder.ClearScreen(bits, _clearCol, _clearDepth, _clearStencil);
     };
 
     // #############################################################################################

--- a/scripts/libWebGL/libWebGL.js
+++ b/scripts/libWebGL/libWebGL.js
@@ -1368,13 +1368,6 @@ function yyWebGL(_canvas, _options) {
 	        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, _gltexture.Image);
         }
 
-        if (texFormatData.internalFormat == gl.DEPTH_STENCIL) {
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-        }
-
         if (_mipoptions !== undefined
             && (_mipoptions == yyGL.MipEnable_On)
              || (_mipoptions == yyGL.MipEnable_OnlyMarked) && ((_gltexture.Flags !== undefined && (_gltexture.Flags & eInternalTextureFlags.GenerateMips) !== 0)))

--- a/scripts/libWebGL/yyCommandBuilder.js
+++ b/scripts/libWebGL/yyCommandBuilder.js
@@ -105,6 +105,7 @@ function yyCommandBuilder(_interpolatePixels) {
         m_destBlendAlpha = gl.ONE_MINUS_SRC_ALPHA;
 
     var m_depthMask,
+        m_stencilMask,
         m_colorMask;
 	    
 	var m_frameCount = 0,
@@ -879,6 +880,7 @@ function yyCommandBuilder(_interpolatePixels) {
 		    break;
     		
 		    case yyGL.RenderState_StencilWriteMask:		
+                m_stencilMask = _renderStateData;
 		        gl.stencilMask(_renderStateData);
 		    break;	
 
@@ -1298,6 +1300,15 @@ function yyCommandBuilder(_interpolatePixels) {
         }
     }
 
+    function SetStencilMask(_value) {
+        if (g_createsurfacedepthbuffers) {
+            gl.stencilMask(_value);
+            m_stencilMask = _value;
+        } else {
+            m_stencilMask = false;
+        }
+    }
+
     function SetColorMask(_r,_g,_b,_a) {
         gl.colorMask(_r,_g,_b,_a);
         m_colorMask = [_r,_g,_b,_a];
@@ -1309,6 +1320,15 @@ function yyCommandBuilder(_interpolatePixels) {
         } else {
             m_depthMask = false;
             return m_depthMask;
+        }
+    }
+
+    function GetStencilMask() {
+        if (g_createsurfacedepthbuffers) {
+            return (m_stencilMask !== null && m_stencilMask !== undefined) ? m_stencilMask : (m_stencilMask = gl.getParameter(gl.STENCIL_WRITEMASK));
+        } else {
+            m_stencilMask = false;
+            return m_stencilMask;
         }
     }
 
@@ -1354,9 +1374,9 @@ function yyCommandBuilder(_interpolatePixels) {
                 // Clear the screen
                 case CMD_CLEARSCREEN:
                     {
-                        var depthMask = gl.getParameter(gl.DEPTH_WRITEMASK);
-                        var colorMask = gl.getParameter(gl.COLOR_WRITEMASK);
-                        var stencilMask = gl.getParameter(gl.STENCIL_WRITEMASK);
+                        var depthMask = GetDepthMask();
+                        var colorMask = GetColorMask();
+                        var stencilMask = GetStencilMask();
                         gl.depthMask(true);
                         gl.colorMask(true, true, true, true);
                         var col = m_commandList[i + 2];
@@ -1364,9 +1384,9 @@ function yyCommandBuilder(_interpolatePixels) {
                         gl.clearDepth(m_commandList[i + 3]);
                         gl.clearStencil(m_commandList[i + 4]);
                         gl.clear(m_commandList[i + 1]);
-                        gl.depthMask(depthMask);
-                        gl.colorMask(colorMask[0], colorMask[1], colorMask[2], colorMask[3]);
-                        gl.stencilMask(stencilMask);
+                        SetDepthMask(depthMask);
+                        SetColorMask(colorMask[0], colorMask[1], colorMask[2], colorMask[3]);
+                        SetStencilMask(stencilMask);
                         i += 5;
                         break;
                     }

--- a/scripts/libWebGL/yyCommandBuilder.js
+++ b/scripts/libWebGL/yyCommandBuilder.js
@@ -416,11 +416,13 @@ function yyCommandBuilder(_interpolatePixels) {
     ///           </summary>
     // #############################################################################################
     /** @this {yyCommandBuilder} */
-    this.ClearScreen = function (_mask,_col) {
+    this.ClearScreen = function (_mask, _clearCol, _clearDepth, _clearStencil) {
 
 	    m_commandList.push(CMD_CLEARSCREEN);
 	    m_commandList.push(_mask);
-	    m_commandList.push(Math.floor(_col));
+	    m_commandList.push(Math.floor(_clearCol));
+	    m_commandList.push(_clearDepth);
+	    m_commandList.push(_clearStencil);
     };
 
     // #############################################################################################
@@ -1324,14 +1326,18 @@ function yyCommandBuilder(_interpolatePixels) {
                     {
                         var depthMask = gl.getParameter(gl.DEPTH_WRITEMASK);
                         var colorMask = gl.getParameter(gl.COLOR_WRITEMASK);
+                        var stencilMask = gl.getParameter(gl.STENCIL_WRITEMASK);
                         gl.depthMask(true);
                         gl.colorMask(true, true, true, true);
-                        col = m_commandList[i + 2];
+                        var col = m_commandList[i + 2];
                         gl.clearColor((col & 0xff) / 255.0, ((col >> 8) & 0xff) / 255.0, ((col >> 16) & 0xff) / 255.0, ((col >>24) & 0xff) / 255.0);
+                        gl.clearDepth(m_commandList[i + 3]);
+                        gl.clearStencil(m_commandList[i + 4]);
                         gl.clear(m_commandList[i + 1]);
                         gl.depthMask(depthMask);
                         gl.colorMask(colorMask[0], colorMask[1], colorMask[2], colorMask[3]);
-                        i += 3;
+                        gl.stencilMask(stencilMask);
+                        i += 5;
                         break;
                     }
                     

--- a/scripts/libWebGL/yyCommandBuilder.js
+++ b/scripts/libWebGL/yyCommandBuilder.js
@@ -1292,21 +1292,13 @@ function yyCommandBuilder(_interpolatePixels) {
     }
 
     function SetDepthMask(_value) {
-        if (g_createsurfacedepthbuffers) {
-            gl.depthMask(_value);
-            m_depthMask = _value;
-        } else {
-            m_depthMask = false;
-        }
+        gl.depthMask(_value);
+        m_depthMask = _value;
     }
 
     function SetStencilMask(_value) {
-        if (g_createsurfacedepthbuffers) {
-            gl.stencilMask(_value);
-            m_stencilMask = _value;
-        } else {
-            m_stencilMask = false;
-        }
+        gl.stencilMask(_value);
+        m_stencilMask = _value;
     }
 
     function SetColorMask(_r,_g,_b,_a) {
@@ -1315,21 +1307,11 @@ function yyCommandBuilder(_interpolatePixels) {
     }
 
     function GetDepthMask() {
-        if (g_createsurfacedepthbuffers) {
-            return (m_depthMask !== null && m_depthMask !== undefined) ? m_depthMask : (m_depthMask = gl.getParameter(gl.DEPTH_WRITEMASK));
-        } else {
-            m_depthMask = false;
-            return m_depthMask;
-        }
+        return (m_depthMask !== null && m_depthMask !== undefined) ? m_depthMask : (m_depthMask = gl.getParameter(gl.DEPTH_WRITEMASK));
     }
 
     function GetStencilMask() {
-        if (g_createsurfacedepthbuffers) {
-            return (m_stencilMask !== null && m_stencilMask !== undefined) ? m_stencilMask : (m_stencilMask = gl.getParameter(gl.STENCIL_WRITEMASK));
-        } else {
-            m_stencilMask = false;
-            return m_stencilMask;
-        }
+        return (m_stencilMask !== null && m_stencilMask !== undefined) ? m_stencilMask : (m_stencilMask = gl.getParameter(gl.STENCIL_WRITEMASK));
     }
 
     function GetColorMask() {

--- a/scripts/libWebGL/yyCommandBuilder.js
+++ b/scripts/libWebGL/yyCommandBuilder.js
@@ -431,10 +431,10 @@ function yyCommandBuilder(_interpolatePixels) {
     ///           </summary>
     // #############################################################################################
     /** @this {yyCommandBuilder} */
-    this.SetRenderTarget = function (_Target) {
-
+    this.SetRenderTarget = function (_color, _depth) {
 	    m_commandList.push(CMD_SETRENDER_TARGET);
-	    m_commandList.push(_Target);
+	    m_commandList.push(_color);
+	    m_commandList.push(_depth);
     };
 
 
@@ -1460,8 +1460,12 @@ function yyCommandBuilder(_interpolatePixels) {
                 // Set the current render target    
                 case CMD_SETRENDER_TARGET:
                     {
-                        gl.bindFramebuffer(gl.FRAMEBUFFER, m_commandList[i + 1]);
-                        i += 2;
+                        var framebuffer = m_commandList[i + 1];
+                        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+                        if (framebuffer != null) {
+                            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, m_commandList[i + 2], 0);
+                        }
+                        i += 3;
                         break;
                     }
                 

--- a/scripts/libWebGL/yyCommandBuilder.js
+++ b/scripts/libWebGL/yyCommandBuilder.js
@@ -1495,7 +1495,11 @@ function yyCommandBuilder(_interpolatePixels) {
                         var framebuffer = m_commandList[i + 1];
                         gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
                         if (framebuffer != null) {
-                            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, m_commandList[i + 2], 0);
+                            if (g_SupportDepthTexture) {
+                                gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, m_commandList[i + 2], 0);
+                            } else {
+                                gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, m_commandList[i + 2]);
+                            }
                         }
                         i += 3;
                         break;

--- a/scripts/libWebGL/yyRenderStateManager.js
+++ b/scripts/libWebGL/yyRenderStateManager.js
@@ -512,8 +512,8 @@ function yyRenderStateManager(_numTextureStages,_stackSize,_commandBuilder,_inte
         m_current.m_renderStates[yyGL.RenderState_StencilPass]=yyGL.StencilOp_Keep; 
         m_current.m_renderStates[yyGL.RenderState_StencilFunc]=yyGL.CmpFunc_CmpAlways; 
         m_current.m_renderStates[yyGL.RenderState_StencilRef]=0; 
-        m_current.m_renderStates[yyGL.RenderState_StencilMask]=0xffffff; 
-        m_current.m_renderStates[yyGL.RenderState_StencilWriteMask]=0xffffff; 
+        m_current.m_renderStates[yyGL.RenderState_StencilMask]=0xff; 
+        m_current.m_renderStates[yyGL.RenderState_StencilWriteMask]=0xff; 
         m_current.m_renderStates[yyGL.RenderState_SeparateAlphaBlendEnable]=false; 
         m_current.m_renderStates[yyGL.RenderState_SrcBlendAlpha]=yyGL.Blend_SrcAlpha; 
         m_current.m_renderStates[yyGL.RenderState_DestBlendAlpha]=yyGL.Blend_InvSrcAlpha; 

--- a/scripts/libWebGL/yyRenderStateManager.js
+++ b/scripts/libWebGL/yyRenderStateManager.js
@@ -512,8 +512,8 @@ function yyRenderStateManager(_numTextureStages,_stackSize,_commandBuilder,_inte
         m_current.m_renderStates[yyGL.RenderState_StencilPass]=yyGL.StencilOp_Keep; 
         m_current.m_renderStates[yyGL.RenderState_StencilFunc]=yyGL.CmpFunc_CmpAlways; 
         m_current.m_renderStates[yyGL.RenderState_StencilRef]=0; 
-        m_current.m_renderStates[yyGL.RenderState_StencilMask]=0xffffffff; 
-        m_current.m_renderStates[yyGL.RenderState_StencilWriteMask]=0xffffffff; 
+        m_current.m_renderStates[yyGL.RenderState_StencilMask]=0xffffff; 
+        m_current.m_renderStates[yyGL.RenderState_StencilWriteMask]=0xffffff; 
         m_current.m_renderStates[yyGL.RenderState_SeparateAlphaBlendEnable]=false; 
         m_current.m_renderStates[yyGL.RenderState_SrcBlendAlpha]=yyGL.Blend_SrcAlpha; 
         m_current.m_renderStates[yyGL.RenderState_DestBlendAlpha]=yyGL.Blend_InvSrcAlpha; 

--- a/scripts/yyBuffer.js
+++ b/scripts/yyBuffer.js
@@ -2908,6 +2908,38 @@ function buffer_get_surface(_buffer, _surface, _offset) {
     return true;
 }
 
+// #############################################################################################
+/// Function:<summary>
+///          	Copy contents of a depth buffer into a regular buffer.
+///          </summary>
+///
+/// In:		<param name="_buffer">The buffer to copy into.</param>
+///			<param name="_surface">The surface whose depth buffer to copy.</param>
+///			<param name="_offset">An offset (in bytes) within the buffer to start writing at.</param>
+///
+/// Out:	 <returns>
+///				Returns true on success or false on fail.
+///			 </returns>
+// #############################################################################################
+function buffer_get_surface_depth(_buffer, _surface, _offset)
+{
+    var pBuff = g_BufferStorage.Get(yyGetInt32(_buffer));
+    var pSurf = g_Surfaces.Get(yyGetInt32(_surface));
+    _offset = yyGetInt32(_offset);
+
+    if (!pBuff) {
+        yyError("buffer_get_surface_depth() - illegal buffer index " + yyGetInt32(_buffer));
+        return false;
+    }
+
+    if (!pSurf) {
+        yyError("buffer_get_surface_depth() - surface does not exist " + yyGetInt32(_surface));
+        return false;
+    }
+
+    // Surfaces don't have depth buffers when WebGL is disabled...
+    return false;
+}
 
 function buffer_set_used_size(_index, _size)
 {
@@ -2963,3 +2995,35 @@ function buffer_set_surface(_buffer, _surface, _offset)
     return true;
 }
 
+// #############################################################################################
+/// Function:<summary>
+///          	Copy data from a regular buffer into a surface's depth buffer.
+///          </summary>
+///
+/// In:		<param name="_buffer">The buffer to copy from.</param>
+///			<param name="_surface">The surface whose depth buffer to copy into.</param>
+///			<param name="_offset">An offset (in bytes) within the buffer to start reading from.</param>
+///
+/// Out:	 <returns>
+///				Returns true on success or false on fail.
+///			 </returns>
+// #############################################################################################
+function buffer_set_surface_depth(_buffer, _surface, _offset)
+{
+    var pBuff = g_BufferStorage.Get(yyGetInt32(_buffer));
+    var pSurf = g_Surfaces.Get(yyGetInt32(_surface));
+    _offset = yyGetInt32(_offset);
+
+    if (!pBuff) {
+        yyError("buffer_set_surface_depth() - illegal buffer index " + yyGetInt32(_buffer));
+        return false;
+    }
+
+    if (!pSurf) {
+        yyError("buffer_set_surface_depth() - surface does not exist " + yyGetInt32(_surface));
+        return false;
+    }
+
+    // Surfaces don't have depth buffers when WebGL is disabled...
+    return false;
+}

--- a/scripts/yyWebGL.js
+++ b/scripts/yyWebGL.js
@@ -86,12 +86,14 @@ var g_extTextureFloat = null;
 var g_extTextureFloatLinear = null;
 var g_extColourBufferFloat = null;
 var g_extStandardDerivatives = null;
+var g_extDepthTexture = null;
 
 var g_SupportHalfFloatSurfs = false;
 var g_SupportFloatSurfs = false;
 var g_SupportSubFourChannelHalfFloatSurfs = false;	
 var g_SupportSubFourChannelFloatSurfs = false;
 var g_SupportSubFourChannelIntSurfs = false;
+var g_SupportDepthTexture = false;
 var g_HalfFloatSurfsUseSizedFormats = false;		
 var g_FloatSurfsUseSizedFormats = false;
 var g_IntSurfsUseSizedFormats = false;

--- a/scripts/yyWebGL.js
+++ b/scripts/yyWebGL.js
@@ -183,7 +183,9 @@ function InitWebGLFunctions() {
     draw_line_width_color = WebGL_draw_line_width_color_RELEASE;
     compile_if_used(draw_line_width_colour = WebGL_draw_line_width_color_RELEASE);
     draw_clear_alpha = WebGL_draw_clear_alpha_RELEASE; // used by yyEffects
-    draw_set_color = WebGL_draw_set_color_RELEASE;
+    compile_if_used(draw_clear_depth = WebGL_draw_clear_depth_RELEASE);
+    compile_if_used(draw_clear_stencil = WebGL_draw_clear_stencil_RELEASE);
+    compile_if_used(draw_clear_ext = WebGL_draw_clear_ext_RELEASE);
     compile_if_used(draw_set_colour = WebGL_draw_set_color_RELEASE);
     draw_set_alpha = WebGL_draw_set_alpha_RELEASE; // used for vkeys
     draw_set_blend_mode_ext = WEBGL_draw_set_blend_mode_ext_RELEASE;
@@ -732,6 +734,79 @@ function WebGL_draw_clear_alpha_RELEASE(_col, _alpha) {
     if (_alpha < 0)  _alpha = 0;
     var col = ((_alpha * 255.0) << 24) | ConvertGMColour(yyGetInt32(_col));
     g_webGL.ClearScreen(true, true, false, col);	
+}
+
+function WebGL_draw_clear_depth_RELEASE(_depth) {
+    g_webGL.ClearScreen(
+        false,
+        true,
+        false,
+        undefined,
+        yyGetReal(_depth),
+        undefined
+    );
+}
+
+function WebGL_draw_clear_stencil_RELEASE(_stencil) {
+    g_webGL.ClearScreen(
+        false,
+        false,
+        true,
+        undefined,
+        undefined,
+        yyGetInt32(_stencil),
+    );
+}
+
+function WebGL_draw_clear_ext_RELEASE(_color, _alpha, _depth, _stencil) {
+    var hasCol, hasAlpha, hasDepth, hasStencil;
+	hasCol = hasAlpha = hasDepth = hasStencil = false;
+    var col, alpha, depth, stencil;
+
+    if (_color !== undefined)
+    {
+        col = ConvertGMColour(yyGetInt32(_col));
+        hasCol = true;
+    }
+
+    if (_alpha !== undefined)
+    {
+        alpha = yyGetReal(_alpha);
+        hasAlpha = true;
+    }
+
+    if (_depth !== undefined)
+    {
+        depth = yyGetReal(_depth);
+        hasDepth = true;
+    }
+
+    if (_stencil !== undefined)
+    {
+        stencil = yyGetInt32(_stencil);
+        hasStencil = true;
+    }
+
+    if (hasCol && !hasAlpha)
+    {
+        yyError("draw_clear_ext() - argument alpha must be specified if argument col is not undefined");
+        return;
+    }
+
+    if (hasAlpha && !hasCol)
+    {
+        yyError("draw_clear_ext() - argument col must be specified if argument alpha is not undefined");
+        return;
+    }
+
+    g_webGL.ClearScreen(
+        hasCol,
+        hasDepth,
+        hasStencil,
+        ((alpha * 255.0) << 24) | col,
+        depth,
+        stencil,
+    );
 }
 
 // #############################################################################################

--- a/scripts/yyWebGL.js
+++ b/scripts/yyWebGL.js
@@ -765,7 +765,7 @@ function WebGL_draw_clear_ext_RELEASE(_color, _alpha, _depth, _stencil) {
 
     if (_color !== undefined)
     {
-        col = ConvertGMColour(yyGetInt32(_col));
+        col = ConvertGMColour(yyGetInt32(_color));
         hasCol = true;
     }
 
@@ -3543,6 +3543,7 @@ function initTextureFramebuffer(_pTPE, _w,_h, _format) {
     
     _pTPE.FrameBuffer = frameBufferData.FrameBuffer;
     _pTPE.texture.webgl_textureid = frameBufferData.Texture;	
+    _pTPE.textureDepth.webgl_textureid = frameBufferData.textureDepth;	
 }
 
 
@@ -3577,12 +3578,16 @@ function WebGL_surface_create_RELEASE(_w, _h, _format, _forceid) {
     var pTPE = new yyTPageEntry();
    
     pTPE.texture = document.createElement("surf");		// we need an image/surface to attach to, so make a small one
-    pTPE.m_Width = _w;
-    pTPE.m_Height = _h;
     pTPE.texture.width = _w;
     pTPE.texture.height = _h;
     pTPE.texture.m_Width = _w;
     pTPE.texture.m_Height = _h;    
+
+    pTPE.textureDepth = document.createElement("surf");
+    pTPE.textureDepth.width = _w;
+    pTPE.textureDepth.height = _h;
+    pTPE.textureDepth.m_Width = _w;
+    pTPE.textureDepth.m_Height = _h;
 
     if( _forceid != undefined )
     {
@@ -3600,6 +3605,8 @@ function WebGL_surface_create_RELEASE(_w, _h, _format, _forceid) {
     pTPE.y = 0;
     pTPE.w = _w;
     pTPE.h = _h;
+    pTPE.m_Width = _w;
+    pTPE.m_Height = _h;
     pTPE.XOffset = 0;
     pTPE.YOffset = 0;
     pTPE.CropWidth = pTPE.w;
@@ -3619,6 +3626,7 @@ function WebGL_surface_create_RELEASE(_w, _h, _format, _forceid) {
 	}
     pTPE.m_pTPE = pTPE;				// Canvas compatability
     pTPE.texture.complete = true;
+    pTPE.textureDepth.complete = true;
 
     // Add cache details	
     pTPE.cache = [];                // clear colour cache
@@ -3662,6 +3670,7 @@ function WebGL_surface_free_RELEASE(_id) {
         
         // Make sure we aren't holding onto an invalid texture id
 	    pSurf.texture.webgl_textureid = undefined;
+	    pSurf.textureDepth.webgl_textureid = undefined;
 	    
 	    g_Surfaces.DeleteIndex(_id);
     } else if (!pSurf) {

--- a/scripts/yyWebGL.js
+++ b/scripts/yyWebGL.js
@@ -264,6 +264,8 @@ function InitWebGLFunctions() {
     buffer_set_surface = WEBGL_buffer_set_surface;
     // @endif
     // 
+    compile_if_used(buffer_get_surface_depth = WEBGL_buffer_get_surface_depth);
+    compile_if_used(buffer_set_surface_depth = WEBGL_buffer_set_surface_depth);
     PostInitWebGLFunctions();	    	
 }
 
@@ -5170,6 +5172,38 @@ function WEBGL_buffer_get_surface(_buffer, _surface, _mode, _offset, _modulo) {
 
 // #############################################################################################
 /// Function:<summary>
+///          	Copy contents of a depth buffer into a regular buffer.
+///          </summary>
+///
+/// In:		<param name="_buffer">The buffer we to copy into.</param>
+///			<param name="_surface">The surface whose depth buffer to copy.</param>
+///			<param name="_offset">An offset (in bytes) within the buffer to start writing at.</param>
+///
+/// Out:	 <returns>
+///				Returns true on success or false on fail.
+///			 </returns>
+// #############################################################################################
+function WEBGL_buffer_get_surface_depth(_buffer, _surface, _offset) {
+    var pBuff = g_BufferStorage.Get(yyGetInt32(_buffer));
+    var pSurf = g_Surfaces.Get(yyGetInt32(_surface));
+    _offset = yyGetInt32(_offset);
+
+    if (!pBuff) {
+        yyError("buffer_get_surface_depth() - illegal buffer index " + yyGetInt32(_buffer));
+        return false;
+    }
+
+    if (!pSurf) {
+        yyError("buffer_get_surface_depth() - surface does not exist " + yyGetInt32(_surface));
+        return false;
+    }
+
+    // Not supported in WebGL...
+    return false;
+}
+
+// #############################################################################################
+/// Function:<summary>
 ///          	Get a surface (CANVAS) into a buffer
 ///          </summary>
 ///
@@ -5197,3 +5231,34 @@ function WEBGL_buffer_set_surface(_buffer, _surface, _mode, _offset, _modulo) {
     data = null;      // free Uint8Array[]
 }
 
+// #############################################################################################
+/// Function:<summary>
+///          	Copy data from a regular buffer into a surface's depth buffer.
+///          </summary>
+///
+/// In:		<param name="_buffer">The buffer to copy from.</param>
+///			<param name="_surface">The surface whose depth buffer to copy into.</param>
+///			<param name="_offset">An offset (in bytes) within the buffer to start reading from.</param>
+///
+/// Out:	 <returns>
+///				Returns true on success or false on fail.
+///			 </returns>
+// #############################################################################################
+function WEBGL_buffer_set_surface_depth(_buffer, _surface, _offset) {
+    var pBuff = g_BufferStorage.Get(yyGetInt32(_buffer));
+    var pSurf = g_Surfaces.Get(yyGetInt32(_surface));
+    _offset = yyGetInt32(_offset);
+
+    if (!pBuff) {
+        yyError("buffer_set_surface_depth() - illegal buffer index " + yyGetInt32(_buffer));
+        return false;
+    }
+
+    if (!pSurf) {
+        yyError("buffer_set_surface_depth() - surface does not exist " + yyGetInt32(_surface));
+        return false;
+    }
+
+    // Not supported in WebGL...
+    return false;
+}

--- a/scripts/yyWebGL.js
+++ b/scripts/yyWebGL.js
@@ -744,7 +744,7 @@ function WebGL_draw_clear_depth_RELEASE(_depth) {
         true,
         false,
         undefined,
-        yyGetReal(_depth),
+        yyGetReal(_depth) * 0.5 + 0.5,
         undefined
     );
 }
@@ -779,7 +779,7 @@ function WebGL_draw_clear_ext_RELEASE(_color, _alpha, _depth, _stencil) {
 
     if (_depth !== undefined)
     {
-        depth = yyGetReal(_depth);
+        depth = yyGetReal(_depth) * 0.5 + 0.5;
         hasDepth = true;
     }
 


### PR DESCRIPTION
# Changes

## Depth buffer functions

* Added new function `surface_has_depth(surface)`, which retrieves whether given surface has a depth buffer (depth buffers can be disabled with existing function `surface_depth_disable`).
* Added new function `surface_get_texture_depth(surface)`, which retrieves a pointer to a texture of a surface's depth buffer. This pointer can be used for example in functions `vertex_submit` and `texture_set_stage` to sample the depth texture in a shader.

> Following code can be used to convert depth buffer values to range 0..1 in shaders:
>
> ```glsl
> precision highp float; // Might be required on some platforms!
> 
> float LinearizeDepth(float depth, float znear, float zfar)
> {
>     return (2.0 * znear) / (zfar + znear - depth * (zfar - znear));
> }
> ```

* Function `surface_set_target` now takes an optional "depth_id" parameter (becoming `surface_set_target(surface_id, [depth_id])`), which can be used to specify a surface whose depth buffer should be used as the current one. When the argument is not specified, it defaults to "surface_id".
* Added new function `surface_get_target_depth()`, which retrieves the surface whose depth buffer is currently used.

## Stencil functions

* Added new constant type `Constant.StencilOp` and following constants used to configure stencil test operations:
  * `stencilop_keep` - Keeps the current value in the stencil buffer.
  * `stencilop_zero` - Sets the stencil buffer value to 0.
  * `stencilop_replace` - Sets the stencil buffer value to the stencil reference value.
  * `stencilop_incr` - Increments the stencil buffer value, clamping at the maximum value.
  * `stencilop_incr_wrap` - Increments the stencil buffer value, wrapping to 0 at the maximum value.
  * `stencilop_decr` - Decrements the stencil buffer value, clamping at 0.
  * `stencilop_decr_wrap` - Decrements the stencil buffer value, wrapping to the maximum value at 0.
  * `stencilop_invert` - Performs a bitwise inversion on the current stencil buffer value.
* Function `gpu_get_state` was modified to also return following keys:
  * "stencilenable" - `true` if stencil test is enabled, otherwise `false`.
  * "stencilfunc" - The current stencil test function (`Constant.ZFunction`).
  * "stencilref" - The current stencil reference value (`Real`).
  * "stencilreadmask" - The current stencil read mask (`Real`).
  * "stencilwritemask" - The current stencil write mask (`Real`).
  * "stencilfail" - The stencil operation executed when the stencil test fails (`Constant.StencilOp`).
  * "stencilzfail" - The stencil operation executed when the stencil test passes but the depth test fails (`Constant.StencilOp`).
  * "stencilpass" - The stencil operation executed when both stencil and depth test pass (`Constant.StencilOp`).
* Function `gpu_set_state` now accepts new keys from `gpu_get_state`.
* Added new function `gpu_set_stencil_enable(enable)`, which can be used to enable/disable stencil test.
* Added new function `gpu_get_stencil_enable()`, which retrieves whether stencil test is enabled.
* Added new function `gpu_set_stencil_func(cmp_func)`, which sets the stencil test function. Argument `cmp_func` must be one of the existing `Constant.ZFunction` constants.
* Added new function `gpu_get_stencil_func()`, which retrieves the current stencil test function.
* Added new function `gpu_set_stencil_ref(ref)`, which can be used to configure the stencil ref value.
* Added new function `gpu_get_stencil_ref()`, which retrieves the current stencil ref value.
* Added new function `gpu_set_stencil_read_mask(mask)`, which can be used to configure the stencil read mask.
* Added new function `gpu_get_stencil_read_mask()`, which retrieves the current stencil read mask.
* Added new function `gpu_set_stencil_write_mask(mask)`, which can be used to configure the stencil write mask.
* Added new function `gpu_get_stencil_write_mask()`, which retrieves the current stencil write mask.
* Added new function `gpu_set_stencil_fail(stencil_op)`, which can be used to configure the stencil operation taken when the stencil test fails.
* Added new function `gpu_get_stencil_fail()`, which retrieves the current stencil operation taken when the stencil test fails.
* Added new function `gpu_set_stencil_depth_fail(stencil_op)`, which can be used to configure the stencil operation taken when the stencil test passes but depth test fails.
* Added new function `gpu_get_stencil_depth_fail()`, which retrieves the current stencil operation taken when the stencil test passes but depth test fails.
* Added new function `gpu_set_stencil_pass(stencil_op)`, which can be used to configure the stencil operation taken when both stencil and depth test pass.
* Added new function `gpu_set_stencil_pass(stencil_op)`, which retrieves the current stencil operation taken when both stencil and depth test pass.

## Depth and stencil clearing functions

* Added new function `draw_clear_depth(depth)`, which can be used to clear just the depth buffer to given value, leaving the color and stencil unaffected.
* Added new function `draw_clear_stencil(stencil)`, which can be used to clear just the stencil buffer to given value, leaving the color and depth unaffected.
* Added new function `draw_clear_ext([col], [alpha], [depth], [stencil])`, which can be used to clear color, depth or stencil, based on which arguments are provided.

## Buffer functions

* Added new function `buffer_get_surface_depth(buffer, surface, offset)`, which can be used to copy values from a surface's depth buffer into a regular buffer (similarly to `buffer_get_surface`, which copies color). **Not supported on platforms running OpenGL ES/WebGL!**
* Added new function `buffer_set_surface_depth(buffer, surface, offset)`, which can be used to copy values from a regular buffer into a surface's depth buffer (similarly to `buffer_set_surface`, which copies color). **Not supported on platforms running OpenGL ES/WebGL!**

--------

Issue link: https://github.com/YoYoGames/GameMaker-Feature-Requests/issues/581
