### PR TITLE
small fix to AudioEmitter

### DIFF
--- a/scripts/sound/AudioEmitter.js
+++ b/scripts/sound/AudioEmitter.js
@@ -15,7 +15,7 @@ class AudioEmitter {
 }
 
 AudioEmitter.createPannerNode = function() {
-    if (PannerNode === undefined) {
+    if (typeof PannerNode === undefined) {
         return g_WebAudioContext.createPanner();
     }
 


### PR DESCRIPTION
If typeof is missing here, the error "ReferenceError: Can't find variable: PannerNode" is thrown