### PR TITLE
potential fix for event_perform_async

### DIFF
--- a/scripts/functions/Function_Game.js
+++ b/scripts/functions/Function_Game.js
@@ -373,7 +373,7 @@ function event_perform_async(_pInst, _pOther, _event, _ds_map)
     _event = yyGetInt32(_event);
     _ds_map = yyGetInt32(_ds_map);
     g_pBuiltIn.async_load = _ds_map;
-    g_pObjectManager.ThrowEvent(EVENT_OTHER,_event);
+    g_pObjectManager.ThrowEvent(EVENT_OTHER | _event,0,true);
 	
 	ds_map_destroy(_ds_map);
 	


### PR DESCRIPTION
An attempt at fixing [a bug in event_perform_async](https://github.com/YoYoGames/GameMaker-Bugs/issues/5078) that causes async events to not fire. Sinc ethis only patches the function behind `event_perform_async`, other effects should be minimal