### PR TITLE
Fixed, calling `slice` on arguments array not permitted

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -5090,7 +5090,7 @@ function fx_set_parameter(_effect, _name, _val)
     }
     else
     {
-        var arr = arguments.slice(2);
+        var arr = Array.prototype.slice.call(arguments, 2);
         _effect.instance.SetParamVar(_name, arr);
     }
 }


### PR DESCRIPTION
Closes: https://github.com/YoYoGames/GameMaker-Bugs/issues/5096