### PR TITLE
Add flag to skeleton_animation_clear() to reset skeleton state.

### DIFF
--- a/scripts/animation/yySkeletonInstance.js
+++ b/scripts/animation/yySkeletonInstance.js
@@ -1432,11 +1432,15 @@ yySkeletonInstance.prototype.GetAnimation = function (_track) {
 ///             Clear the animation at the given track
 ///          </summary>
 // #############################################################################################
-yySkeletonInstance.prototype.ClearAnimation = function (_track) {
-
-    if ((_track >= 0) && (_track < this.m_animationState.tracks.length)) {
-		this.m_animationState.clearTrack(_track);
-	}	
+yySkeletonInstance.prototype.ClearAnimation = function (_track, _reset, _mixDuration) {
+	if ((_track >= 0) && (_track < this.m_animationState.tracks.length)) {
+		if(_reset) {
+			this.m_animationState.setEmptyAnimation(_track, _mixDuration);
+		}
+		else{
+			this.m_animationState.clearTrack(_track);
+		}
+	}
 };
 
 // #############################################################################################

--- a/scripts/functions/Function_Graphics.js
+++ b/scripts/functions/Function_Graphics.js
@@ -2293,13 +2293,28 @@ function skeleton_animation_get_event_frames(_inst, _anim, _event)
 ///             Clear the animation at the given track
 ///          </summary>
 // #############################################################################################
-function skeleton_animation_clear(_inst, _track) {
+function skeleton_animation_clear(_inst, _track, _reset, _mixDuration) {
+	if(_reset === undefined)
+	{
+		_reset = false;
+	}
+	else{
+		_reset = yyGetBool(_reset);
+	}
 
-    var skeletonAnim = _inst.SkeletonAnimation();
-    if (skeletonAnim)
-	{		
-        skeletonAnim.ClearAnimation(yyGetInt32(_track));
-	}	
+	if(_mixDuration === undefined)
+	{
+		_mixDuration = 0.0;
+	}
+	else{
+		_mixDuration = yyGetReal(_mixDuration);
+	}
+
+	var skeletonAnim = _inst.SkeletonAnimation();
+	if (skeletonAnim)
+	{
+		skeletonAnim.ClearAnimation(yyGetInt32(_track), _reset, _mixDuration);
+	}
 }
 
 // #############################################################################################


### PR DESCRIPTION
Removing an animation leaves any transforms/etc it applied to the skeleton in place, this commit adds a "reset" argument which may be passed to skeleton_animation_clear() to transform the skeleton back to its setup pose. The duration parameter is optional, if not specified the skeleton will snap back to its setup pose in one frame.

https://github.com/YoYoGames/GameMaker-Bugs/issues/1570