### PR TITLE
[HTML5] Fix for move_snap when passed 0 or negative grid size

### DIFF
--- a/scripts/functions/Function_Movement.js
+++ b/scripts/functions/Function_Movement.js
@@ -219,8 +219,10 @@ function move_snap(_pInst,_hsnap,_vsnap)
     _hsnap = yyGetReal(_hsnap);
     _vsnap = yyGetReal(_vsnap);
 
-    _pInst.x = Round(_pInst.x/_hsnap) * _hsnap;
-    _pInst.y = Round(_pInst.y/_vsnap) * _vsnap;
+	if(_hsnap>0)
+    	_pInst.x = Round(_pInst.x/_hsnap) * _hsnap;
+	if(_vsnap>0)
+    	_pInst.y = Round(_pInst.y/_vsnap) * _vsnap;
     _pInst.bbox_dirty = true;
 }
 


### PR DESCRIPTION
(to match C++ runner)
https://github.com/YoYoGames/GameMaker-HTML5/issues/462