### PR TITLE
[HTML5] Removed zero width no break space

### DIFF
--- a/scripts/functions/Function_Room.js
+++ b/scripts/functions/Function_Room.js
@@ -1,4 +1,4 @@
-﻿﻿
+﻿// Removed zero width no break space
 // **********************************************************************************************************************
 // 
 // Copyright (c)2011, YoYo Games Ltd. All Rights reserved.


### PR DESCRIPTION
that was confusing the obfuscator (hopefully git does actually remove this, it didn't show as a diff when I just deleted it) https://github.com/YoYoGames/GameMaker/issues/3788