### PR TITLE
Decoding voice state changes

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -441,6 +441,8 @@ audioSound.prototype.play = function() {
     if (g_WebAudioContext === null)
         return;
 
+    this.bActive = true;
+
     const asset = Audio_GetSound(this.soundid);
 
     if (asset.state !== AudioSampleState.READY ) {
@@ -495,8 +497,6 @@ audioSound.prototype.play = function() {
             this.start(asset.buffer);
         }
     }
-
-    this.bActive = true;
 };
 
 audioSound.prototype.stop = function() {


### PR DESCRIPTION
Makes voices waiting for an asset to be decoded considered active, so that they return `true` from `audio_is_playing`.

Relates to https://github.com/YoYoGames/GameMaker-Bugs/issues/4794