### PR TITLE
Remove call to non-existent listener function

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -2113,7 +2113,6 @@ function audio_listener_velocity( _one,_two,_three)
         _three = yyGetReal(_three);
 
         var lis = g_WebAudioContext.listener;
-        lis.setVelocity( _one, _two, _three );
 
     	// AB: Need to check if pos exists - can be undefined on some browsers
         if ( lis.velocity )


### PR DESCRIPTION
WebAudio's `AudioListener` does not support velocity in any way, nor do we define the function `setVelocity` on the audio context's listener ourselves. It seems that this call was redundant anyway as the velocity properties are updated immediately after.

Listener velocity is tracked in HTML5 so that it can be included in the ds-map returned by `audio_listener_get_data`, but it does not have any audible effect.