### PR TITLE
Gif add surface testing

### DIFF
--- a/scripts/libWebGL/libWebGL.js
+++ b/scripts/libWebGL/libWebGL.js
@@ -1542,7 +1542,7 @@ function yyWebGL(_canvas, _options) {
     ///          </summary>
     // #############################################################################################
     /** @this {yyWebGL} */
-    this.CreateTextureFromFramebuffer = function (_image, _frameBuffer, _x, _y, _w, _h, _removeback, _smooth) {
+    this.CreateTextureFromFramebuffer = function (_image, _frameBuffer, _x, _y, _w, _h, _removeback, _smooth, _scale_to_power=true) {
 
         // Execute current list to ensure what we grab is actually what should've been drawn now
 	    this.FlushAll();
@@ -1563,9 +1563,13 @@ function yyWebGL(_canvas, _options) {
 	        RemoveBackground(new Int32Array(pixelData), _w, _h);
 	    }
 				
-	    // Get the power of 2 size for the texture creation
-        var w = GetPOW2Alignment(_w);
-        var h = GetPOW2Alignment(_h);
+	    // Get the power of 2 size for the texture creation (but avoid this )
+        var w = _w;
+        var h = _h;
+        if (_scale_to_power) {
+            w = GetPOW2Alignment(_w);
+            h = GetPOW2Alignment(_h);
+        }
         
         // Store the current texture before rebinding the texture unit
         var storedTexture = gl.getParameter(gl.TEXTURE_BINDING_2D);

--- a/scripts/yyGraphics.js
+++ b/scripts/yyGraphics.js
@@ -1783,6 +1783,7 @@ function gif_add_surface(gif, surface, delaytime, xoffset, yoffset, quantquality
 	if (yoffset === undefined) yoffset = 0;
 
 	var pSurf = g_Surfaces.Get(yyGetInt32(surface));
+	
     if (pSurf != null) {
 
 		if (pSurf.FrameBufferData.Texture.Format != eTextureFormat_A8R8G8B8)
@@ -1815,10 +1816,11 @@ function gif_add_surface(gif, surface, delaytime, xoffset, yoffset, quantquality
         var singleimage = document.createElement(g_CanvasName);
         var pGraphics = singleimage.getContext('2d');
         Graphics_AddCanvasFunctions(pGraphics); 			// update for OUR functions.
-
-        var glTexture = g_webGL.CreateTextureFromFramebuffer(singleimage, pSurf.FrameBuffer, yyGetInt32(xoffset), yyGetInt32(yoffset), encoder.getWidth(), encoder.getHeight(), false, false);
-
-        encoder.addFrame(Uint8ClampedArray.from(glTexture.Image), true);
+		console.log(`${encoder.getWidth()}-${encoder.getHeight()}`);
+        var glTexture = g_webGL.CreateTextureFromFramebuffer(singleimage, pSurf.FrameBuffer, yyGetInt32(xoffset), yyGetInt32(yoffset), encoder.getWidth(), encoder.getHeight(), false, false, false);
+		const uint8array = Uint8ClampedArray.from(glTexture.Image);
+		//console.log(glTexture);
+        encoder.addFrame(uint8array, true);
     }
 };
 

--- a/scripts/yyGraphics.js
+++ b/scripts/yyGraphics.js
@@ -1818,9 +1818,7 @@ function gif_add_surface(gif, surface, delaytime, xoffset, yoffset, quantquality
         Graphics_AddCanvasFunctions(pGraphics); 			// update for OUR functions.
 		console.log(`${encoder.getWidth()}-${encoder.getHeight()}`);
         var glTexture = g_webGL.CreateTextureFromFramebuffer(singleimage, pSurf.FrameBuffer, yyGetInt32(xoffset), yyGetInt32(yoffset), encoder.getWidth(), encoder.getHeight(), false, false, false);
-		const uint8array = Uint8ClampedArray.from(glTexture.Image);
-		//console.log(glTexture);
-        encoder.addFrame(uint8array, true);
+        encoder.addFrame(Uint8ClampedArray.from(glTexture.Image), true);
     }
 };
 


### PR DESCRIPTION
This is an attempt to fix [a bug with `gif_surface_add()`](https://github.com/YoYoGames/GameMaker-Bugs/issues/5436).

Adds a new parameter to `CreateTextureFromFramebuffer` in `libWebGL.js that allows textures to not be resized to a power of 2 which is what appears to cause the issue in `gif_surface_add()`