### PR TITLE
Fixes issues with `array_` and `string_` when skipping opt arguments

### DIFF
--- a/scripts/functions/Function_String.js
+++ b/scripts/functions/Function_String.js
@@ -1241,7 +1241,7 @@ function string_split(_str, _delim, _removeEmpty, _maxSplits) {
     }
 
     // Get optional arguments
-    _removeEmpty = arguments.length > 2 ? yyGetReal(_removeEmpty) : false;
+    _removeEmpty = _removeEmpty != undefined ? yyGetReal(_removeEmpty) : false;
     _maxSplits = arguments.length > 3 ? yyGetReal(_maxSplits) : _str.length;
 
     // Escape regex symbols from delimiter.
@@ -1267,7 +1267,7 @@ function string_split_ext(_str, _delims, _removeEmpty, _maxSplits) {
     }
 
     // Get optional arguments
-    _removeEmpty = arguments.length > 2 ? yyGetReal(_removeEmpty) : false;
+    _removeEmpty = _removeEmpty != undefined ? yyGetReal(_removeEmpty) : false;
     _maxSplits = arguments.length > 3 ? yyGetReal(_maxSplits) : _str.length;
 
     // Convert delimiter to string, escape the pipe symbols, remove empty entries.
@@ -1313,7 +1313,7 @@ function string_join_ext(_delim, _values, _offset, _length) {
     }
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _values.length; 
 
     var _itValues = computeIterationValues(_values.length, _offset, _length);
@@ -1352,7 +1352,7 @@ function string_concat_ext(_values, _offset, _length) {
     }
 
     // Check raw offset and length
-    _offset = arguments.length > 1 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 2 ? yyGetReal(_length) : _values.length; 
 
     var _itValues = computeIterationValues(_values.length, _offset, _length);
@@ -1387,7 +1387,7 @@ function string_foreach(_str, _func, _pos, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _pos = arguments.length > 3 ? yyGetReal(_pos) : 1;
+    _pos = _pos != undefined ? yyGetReal(_pos) : 1;
     _length = arguments.length > 3 ? yyGetReal(_length) : _str.length;
 
     var _offset = (_pos < 0 ? _pos : (_pos > 0 ? _pos - 1 : 0));

--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -789,7 +789,7 @@ const shuffleArray = (_array, _offset, _length) => {
 function array_shuffle( _array, _offset, _length )
 {
     // Check raw offset and length
-    _offset = arguments.length > 1 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 2 ? yyGetReal(_length) : _array.length; 
 
     var ret = undefined;
@@ -820,7 +820,7 @@ function array_shuffle( _array, _offset, _length )
 function array_shuffle_ext(_array, _offset, _length)
 {
     // Check raw offset and length
-    _offset = arguments.length > 1 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 2 ? yyGetReal(_length) : _array.length; 
 
     var ret = undefined;
@@ -895,7 +895,7 @@ function array_find_index(_array, _func, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -925,7 +925,7 @@ function array_get_index(_array, _value, _offset, _length) {
     if (!Array.isArray(_array)) yyError("array_get_index : argument0 is not an array");
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -956,7 +956,7 @@ function array_contains(_array, _value, _offset, _length) {
     if (!Array.isArray(_array)) yyError("array_contains : argument0 is not an array");
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -995,8 +995,8 @@ function array_contains_ext(_array, _values, _matchAll, _offset, _length) {
     if (subArrayLength == 0) return true;
 
     // Check raw offset and length
-    _matchAll = _offset = arguments.length > 2 ? yyGetBool(_matchAll) : false;
-    _offset = arguments.length > 3 ? yyGetReal(_offset) : 0;
+    _matchAll = _matchAll != undefined ? yyGetBool(_matchAll) : false;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 4 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1051,7 +1051,7 @@ function array_any(_array, _func, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1087,7 +1087,7 @@ function array_all(_array, _func, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1123,7 +1123,7 @@ function array_foreach(_array, _func, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1154,7 +1154,7 @@ function array_reduce(_array, _func, _init, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 3 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 4 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1195,7 +1195,7 @@ function array_filter(_array, _func, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1234,7 +1234,7 @@ function array_filter_ext(_array, _func, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1274,7 +1274,7 @@ function array_map(_array, _func, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1311,7 +1311,7 @@ function array_map_ext(_array, _func, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1348,7 +1348,7 @@ function array_copy_while(_array, _func, _offset, _length) {
     _obj = "boundObject" in _func ? _func.boundObject : {};
 
     // Check raw offset and length
-    _offset = arguments.length > 2 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1384,7 +1384,7 @@ function array_unique(_array, _offset, _length) {
     if (!Array.isArray(_array)) yyError("array_unique : argument0 is not an array");
 
     // Check raw offset and length
-    _offset = arguments.length > 1 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 2 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1418,7 +1418,7 @@ function array_unique_ext(_array, _offset, _length) {
     if (!Array.isArray(_array)) yyError("array_unique_ext : argument0 is not an array");
 
     // Check raw offset and length
-    _offset = arguments.length > 1 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 2 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1454,7 +1454,7 @@ function array_reverse(_array, _offset, _length) {
     if (!Array.isArray(_array)) yyError("array_reverse : argument0 is not an array");
 
     // Check raw offset and length
-    _offset = arguments.length > 1 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 2 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
@@ -1487,7 +1487,7 @@ function array_reverse_ext(_array, _offset, _length) {
     if (!Array.isArray(_array)) yyError("array_reverse_ext : argument0 is not an array");
 
     // Check raw offset and length
-    _offset = arguments.length > 1 ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 2 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values


### PR DESCRIPTION
Fixes: https://github.com/YoYoGames/GameMaker-Bugs/issues/5593

Most new `array_` and `string_` function have optional arguments that when skipped (ie.: `array_foreach(array, /* skipped arg */ , infinity)`) would result in errors.