### PR TITLE
Sequence fixes

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -5046,8 +5046,8 @@ function layer_sequence_create(layer_id, posx, posy, sequence_id)
     newSeqEl.m_blend = -1;
     newSeqEl.m_scaleX = 1;
     newSeqEl.m_scaleY = 1;
-    newSeqEl.m_x = posx;
-    newSeqEl.m_y = posy;
+    newSeqEl.m_x = yyGetReal(posx);
+    newSeqEl.m_y = yyGetReal(posy);
     newSeqEl.m_angle = 0;
     newSeqEl.m_name = sequence.name;
 

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -5717,9 +5717,9 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
                                     timefromstart = 0.0;
                             }
 
-                            if ((_pSeq.m_playbackSpeed * _pInst.speedScale) > 0.0)
+                            if ((_pSeq.m_playbackSpeed * _pInst.m_speedScale) > 0.0)
                             {
-                                timefromstart /= (_pSeq.m_playbackSpeed * _pInst.speedScale);;
+                                timefromstart /= (_pSeq.m_playbackSpeed * _pInst.m_speedScale);
                             }
                             audio_sound_set_track_position(pAudioInfo.soundindex, timefromstart);
                         }


### PR DESCRIPTION
**Changes**
- Wraps `posx` and `posy` of `layer_sequence_create` in calls to `yyGetReal` as they may not necessarily be a number (e.g. a `Long` object)
- Replaces use of an undefined variable `speedScale` in `HandleAudioTrackUpdate` with the intended variable `m_speedScale`.

**Relates to**
- https://github.com/YoYoGames/GameMaker-Bugs/issues/4966
- https://github.com/YoYoGames/GameMaker-Bugs/issues/4967
