### PR TITLE
Audio track update fixes

### DIFF
--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -5682,7 +5682,7 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
                         if (pAudioInfo.soundindex != -1)
                         {
                             // See if we need to stop and restart this sound
-                            if (((pAudioInfo.playdir * _headDir) <= 0) || (((_headPos - _lastHeadPos) * pAudioInfo.playdir) <= 0))
+                            if (((pAudioInfo.playdir * _headDir) < 0) || (((_headPos - _lastHeadPos) * pAudioInfo.playdir) < 0))
                             {
                                 audio_stop_sound(pAudioInfo.soundindex);
                                 pAudioInfo.soundindex = -1;

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -5702,8 +5702,7 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
 							}
 
                             pAudioInfo.playdir = _headDir;
-                            pAudioInfo.soundindex = audio_play_sound_on(pAudioInfo.emitterindex, ppChanKey.m_soundIndex, (ppChanKey.m_mode == eSM_Loop) ? true : false, 1.0);
-
+                            
                             // Seek to the correct spot in the sample (this matches the IDE logic)
                             var timefromstart;
                             if (pAudioInfo.playdir > 0)
@@ -5721,7 +5720,16 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
                             {
                                 timefromstart /= (_pSeq.m_playbackSpeed * _pInst.m_speedScale);
                             }
-                            audio_sound_set_track_position(pAudioInfo.soundindex, timefromstart);
+
+                            const props = {
+                                "sound": ppChanKey.m_soundIndex,
+                                "loop": (ppChanKey.m_mode == eSM_Loop),
+                                "priority": 1,
+                                "emitter": pAudioInfo.emitterindex,
+                                "offset": timefromstart
+                            };
+                            audio_emitter_position(pAudioInfo.emitterindex, emitterPosX, emitterPosY, 0.0);
+                            pAudioInfo.soundindex = audio_play_sound_ext(props);
                         }
 
                         if (pAudioInfo.soundindex != -1 && audio_emitter_exists(pAudioInfo.emitterindex) === true)

--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -956,7 +956,7 @@ function array_contains(_array, _value, _offset, _length) {
     if (!Array.isArray(_array)) yyError("array_contains : argument0 is not an array");
 
     // Check raw offset and length
-    _offset = _offset != ? yyGetReal(_offset) : 0;
+    _offset = _offset != undefined ? yyGetReal(_offset) : 0;
     _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values


### PR DESCRIPTION
- Fixes an issue where a pre-draw update would cause audio tracks to be stopped and started again because the play-head appeared to have not moved (which is expected in that scenario).
- Fixes an issue where initial emitter positions/playback offsets of audio tracks were set after playback had been requested and sometimes led to artefacts being generated.
- The above relates to https://github.com/YoYoGames/GameMaker-Bugs/issues/2362.
- Finally, picks the unrelated but necessary fix https://github.com/YoYoGames/GameMaker-HTML5/commit/3a8a62457fd632cb86499809e5f9a7b12d458dcf.