### PR TITLE
Add audio_sound_get_asset

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3077,6 +3077,15 @@ function audio_sound_get_audio_group(_soundIndex)
     return asset.groupId;
 }
 
+function audio_sound_get_asset(_voiceIndex)
+{
+    const voice = GetAudioSoundFromHandle(_voiceIndex);
+    if (voice === null || voice.bActive === false) {
+        return undefined;
+    }
+    return voice.soundid;
+}
+
 function audio_create_stream(_filename)
 {
     var sampleData = new audioSampleData();


### PR DESCRIPTION
Adds the function `audio_sound_get_asset`, which returns the asset index being played by a given active voice handle, or `undefined` otherwise.

Relates to https://github.com/YoYoGames/GameMaker-Bugs/issues/5861.