### PR TITLE
Quick patch on the real function to use parseInt for any strings detected as hex strings

### DIFF
--- a/scripts/functions/Function_String.js
+++ b/scripts/functions/Function_String.js
@@ -122,7 +122,13 @@ function real(_v) {
     }
     else if (typeof (_v) == "string")
 	{
-        var stringAsNumber = parseFloat(_v);
+        
+        var stringAsNumber;
+        if (_v.startsWith('0x')) {
+            stringAsNumber =  parseInt(_v);
+        } else {
+            stringAsNumber =  parseFloat(_v);
+        }
         if (isNaN(stringAsNumber))
         {
 	        yyError("unable to convert string " + _v + " to real");


### PR DESCRIPTION
Fixes https://github.com/YoYoGames/GameMaker-Bugs/issues/5943

Changes the `real` function in Function_String.js to try parsing strings starting with `0x` using `parseInt` rather than `parseFloat`. 