### PR TITLE
audio_create_buffer_sound aliasing

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3226,8 +3226,8 @@ function audio_create_buffer_sound(_bufferId, _bufferFormat, _sampleRate, _offse
 
     _sampleRate = Math.min(Math.max(_sampleRate, 8000), 48000);
 
-    buffer_seek( _bufferId, eBuffer_Start, 0 );
     var bufferSize = _length;
+    buffer_seek(_bufferId, eBuffer_Start, _offset);
 
     /* Here we prevent the Web Audio context from cleanly resampling the buffer
        to the rate of the audio context by aligning the audio buffer rate with

--- a/scripts/yySprite.js
+++ b/scripts/yySprite.js
@@ -1100,14 +1100,8 @@ yySprite.prototype.CreateMask = function(){
 			pSpr.colmask[0] = TMaskCreate(pSpr.colmask[0], pSpr.ppTPE[i], 0, pSpr.bbox, MASK_PRECISE, 0);
 		}
 	}
-	pSpr.maskcreated = true;   
-
-
-
-
-
-
-}
+	pSpr.maskcreated = true;
+};
 
 
 // #############################################################################################
@@ -1310,7 +1304,7 @@ yySprite.prototype.ColMaskSet=function(u,v,pMaskBase)
 	}
 
 	return true;
-}
+};
 
 yySprite.prototype.CollisionTilemapLine= function (bb2,xl,yl,xr,yr)
 {


### PR DESCRIPTION
- Removes the intentional addition of aliasing in `audio_create_buffer_sound`, which was added in response to [GM-5788](https://bugs.opera.com/browse/GM-5788) to keep buffer sounds somewhat consistent between HTML5 and other platforms. This is no longer needed after https://github.com/YoYoGames/YYAL/pull/99.
- Fixes the `offset` argument to `audio_create_buffer_sound` being ignored.
- Fixes some obfuscation issues in yySprite.js.

Relates to:
- https://github.com/YoYoGames/GameMaker-Bugs/issues/2111.
- https://github.com/YoYoGames/GameMaker-Bugs/issues/2125.