### PR TITLE
Fix mouse position issues when resizing the canvas

### DIFF
--- a/scripts/yyView.js
+++ b/scripts/yyView.js
@@ -98,19 +98,25 @@ yyView.prototype.Copy = function (_src) {
 ///          </summary>
 // #############################################################################################
 yyView.prototype.GetMouseCoord = function(_x,_y,_horizontal) {
-    var pRect = g_CanvasRect;
-
-    _x = (_x - pRect.left - this.scaledportx) / (pRect.scaleX || 1);
-    _y = (_y - pRect.top - this.scaledporty) / (pRect.scaleY || 1);
-
 	var cam = g_pCameraManager.GetCamera(this.cameraID);
 	if (cam == null) return 0;
+
+	var pRect = g_CanvasRect;
+	_x = (_x - pRect.left - this.scaledportx) / (pRect.scaleX || 1);
+	_y = (_y - pRect.top - this.scaledporty) / (pRect.scaleY || 1);
+
+	if (this.cameraID == g_DefaultCameraID) {
+		_x = (_x / this.WorldViewScaleX) + this.worldx;
+		_y = (_y / this.WorldViewScaleY) + this.worldy;
+		return Math.floor((_horizontal ? _x : _y));
+	}
+
 	//
 	var clipX = _x / this.scaledportw;
 	var clipY = _y / this.scaledporth;
 	clipX = clipX * 2.0 - 1.0;
 	clipY = clipY * 2.0 - 1.0;
-	
+
 	// Now backtransform into room space
 	var invViewProj = cam.GetInvViewProjMat();
 


### PR DESCRIPTION
When calling `window_set_size()` (or similar) in a room that doesn't make use of views or cameras, `mouse_x` and `mouse_y` report incorrect coordinates, and elements on the screen are not clickable at their visual positions. This PR fixes this issue. Note that the most important part of the code added in this PR was actually used in GMS 1 as you can see here: https://github.com/YoYoGames/GameMaker-HTML5/blob/04b729be9004fb2a6d17c1c5257910857682256a/scripts/yyView.js#L100-L135

[Attached 2 samples (.ZIP)](https://github.com/user-attachments/files/15519018/samples.zip):
- `_resize.yyz`: Press "Enter" to resize the canvas (you can do this multiple times), notice that the values for mouse_x and mouse_y are incorrect. Also, hovering over the blue square should change the mouse cursor, but this doesn't happen when resized.

- `_resize2.yyz`: This one is based on the HTML5 scaling platformer tutorial. It makes use of cameras, so it was already working before. I'm just including it to show that it still works with this PR. 