### PR TITLE
Set up bounding box on Spine sprites loaded at runtime.

### DIFF
--- a/scripts/yyInstance.js
+++ b/scripts/yyInstance.js
@@ -1446,7 +1446,7 @@ yyInstance.prototype.Compute_BoundingBox = function() {
     var collisionSkel = this.GetCollisionSkeleton();
 
 	// @if feature("spine")
-    if(maskCollisionSkel !== null && g_pSpriteManager.Sprites[this.mask_index].bboxmode == 0 /* "Automatic" */) {
+    if(maskCollisionSkel !== null && g_pSpriteManager.Sprites[this.mask_index].colcheck == yySprite_CollisionType.SPINE_MESH) {
         if (!this.bbox) {
             this.bbox = new YYRECT(0, 0, 0, 0);
         }
@@ -1467,7 +1467,7 @@ yyInstance.prototype.Compute_BoundingBox = function() {
         this.bbox_dirty = false;
         return;
     }
-    if(collisionSkel !== null && g_pSpriteManager.Sprites[this.sprite_index].bboxmode == 0 /* "Automatic" */) {
+    if(collisionSkel !== null && g_pSpriteManager.Sprites[this.sprite_index].colcheck == yySprite_CollisionType.SPINE_MESH) {
         if (!this.bbox) {
             this.bbox = new YYRECT(0, 0, 0, 0);
         }


### PR DESCRIPTION
This commit makes several changes around Spine sprite collision mask handling:

- Initialise the "bboxmode" of a Spine sprite loaded with sprite_add() or sprite_add_ext() to bboxmode_fullimage and compute the bounding box appropriately.

- Allow a limited subset of sprite_collision_mask() on Spine sprites to switch between "Full image" bounding box, manually specified bounding boxes or Spine collision meshes.

- Bail out if sprite_set_bbox_mode() is called with bboxmode_automatic on a Spine sprite since this implies the pixel-based bounding box computed by the IDE, which we can't easily reproduce.

- Refactor yySprite/yyInstance bounding box handling to closer match the native runner.

https://github.com/YoYoGames/GameMaker-Bugs/issues/4712