### PR TITLE
Audio filter fixes

### DIFF
--- a/scripts/sound/AudioEffect.js
+++ b/scripts/sound/AudioEffect.js
@@ -168,8 +168,7 @@ AudioEffectStruct.prototype.updateFreqDesc = function(_desc) {
         return _desc;
     }
 
-    _desc.maxValue = g_WebAudioContext ? Math.min(g_WebAudioContext.sampleRate / 2, _desc.maxValue)
-                                       : _desc.maxValue;
+    _desc.maxValue = g_WebAudioContext ? g_WebAudioContext.sampleRate * 0.45 : _desc.maxValue;
     _desc.defaultValue = Math.min(_desc.defaultValue, _desc.maxValue);
     return _desc;
 };

--- a/scripts/sound/AudioEffect.js
+++ b/scripts/sound/AudioEffect.js
@@ -130,7 +130,7 @@ AudioEffectStruct.prototype.initParams = function(_params) {
 
 AudioEffectStruct.prototype.setParam = function(_idx, _val) {
     const structType = AudioEffectStruct.GetStructType(this.type);
-    const desc = structType.ParamDescriptors[_idx];
+    const desc = this.updateFreqDesc(structType.ParamDescriptors[_idx]);
 
     _val = clamp(_val, desc.minValue, desc.maxValue);
 

--- a/scripts/sound/AudioEffect.js
+++ b/scripts/sound/AudioEffect.js
@@ -186,4 +186,15 @@ AudioEffectStruct.prototype.isFilter = function() {
             return false;
     }
 };
+
+AudioEffectStruct.prototype.getParamMap = function() {
+    const map = {};
+
+    const descriptors = this.getParamDescriptors();
+    descriptors.forEach((_desc, _idx) => {
+        map[_desc.name] = this.params[_idx]
+    });
+
+    return map;
+};
 // @endif

--- a/scripts/sound/WorkletNodeManager.js
+++ b/scripts/sound/WorkletNodeManager.js
@@ -50,7 +50,7 @@ WorkletNodeManager.prototype.createEffect = function(_struct) {
 		numberOfInputs: 1,
 		numberOfOutputs: 1, 
 		outputChannelCount: [maxChannels],
-		parameterData: _struct.params,
+		parameterData: _struct.getParamMap(),
 		channelCount: maxChannels,
 		channelCountMode: "explicit"
 	});

--- a/scripts/sound/effects/EQ.js
+++ b/scripts/sound/effects/EQ.js
@@ -143,7 +143,6 @@ function EQEffectStruct(_params) {
             numberOfInputs: 2,
             numberOfOutputs: 1, 
             outputChannelCount: [maxChannels],
-            parameterData: this.params,
             channelCount: maxChannels,
             channelCountMode: "explicit"
         });

--- a/scripts/sound/effects/LPF2.js
+++ b/scripts/sound/effects/LPF2.js
@@ -45,7 +45,7 @@ LPF2EffectStruct.Index = {
 };
 
 LPF2EffectStruct.ParamDescriptors = [
-    { name: "bypass", integer: true,  defaultValue: 0,      minValue: 0,    maxValue: 1 },
+    { name: "bypass", integer: true,  defaultValue: 0,     minValue: 0,    maxValue: 1 },
     { name: "cutoff", integer: false, defaultValue: 500.0, minValue: 10.0, maxValue: 20000.0 },
     { name: "q",      integer: false, defaultValue: 1.5,   minValue: 1.0,  maxValue: 100.0 } 
 ];

--- a/scripts/sound/effects/PeakEQ.js
+++ b/scripts/sound/effects/PeakEQ.js
@@ -24,7 +24,7 @@ function PeakEQEffectStruct(_params) {
         gmlq: {
             enumerable: true,
             get: () => {
-                return this.params[PeakEQEffectStruct.Index.Freq];
+                return this.params[PeakEQEffectStruct.Index.Q];
             },
             set: (_q) => {
                 const val = this.setParam(PeakEQEffectStruct.Index.Q, _q);
@@ -38,7 +38,7 @@ function PeakEQEffectStruct(_params) {
         gmlgain: {
             enumerable: true,
             get: () => {
-                return this.params[PeakEQEffectStruct.Index.Freq];
+                return this.params[PeakEQEffectStruct.Index.Gain];
             },
             set: (_gain) => {
                 const val = this.setParam(PeakEQEffectStruct.Index.Gain, _gain);

--- a/scripts/sound/worklets/HPF2Processor.js
+++ b/scripts/sound/worklets/HPF2Processor.js
@@ -2,7 +2,7 @@ class HPF2Processor extends AudioWorkletProcessor
 {
     static get parameterDescriptors() 
     {
-        const maxCutoff = Math.min(sampleRate / 2.0, 20000.0);
+        const maxCutoff = sampleRate * 0.45;
 
         return [
             { name: "bypass", automationRate: "a-rate", defaultValue: 0,                           minValue: 0,    maxValue: 1 },

--- a/scripts/sound/worklets/HiShelfProcessor.js
+++ b/scripts/sound/worklets/HiShelfProcessor.js
@@ -2,7 +2,7 @@ class HiShelfProcessor extends AudioWorkletProcessor
 {
     static get parameterDescriptors() 
     {
-        const maxFreq = Math.min(sampleRate / 2.0, 20000.0);
+        const maxFreq = sampleRate * 0.45;
 
         return [
             { name: "bypass", automationRate: "a-rate", defaultValue: 0,                         minValue: 0,    maxValue: 1 },

--- a/scripts/sound/worklets/LPF2Processor.js
+++ b/scripts/sound/worklets/LPF2Processor.js
@@ -2,7 +2,7 @@ class LPF2Processor extends AudioWorkletProcessor
 {
     static get parameterDescriptors() 
     {
-        const maxCutoff = Math.min(sampleRate / 2.0, 20000.0);
+        const maxCutoff = sampleRate * 0.45;
 
         return [
             { name: "bypass", automationRate: "a-rate", defaultValue: 0,                          minValue: 0,    maxValue: 1 },

--- a/scripts/sound/worklets/LoShelfProcessor.js
+++ b/scripts/sound/worklets/LoShelfProcessor.js
@@ -2,7 +2,7 @@ class LoShelfProcessor extends AudioWorkletProcessor
 {
     static get parameterDescriptors() 
     {
-        const maxFreq = Math.min(sampleRate / 2.0, 20000.0);
+        const maxFreq = sampleRate * 0.45;
 
         return [
             { name: "bypass", automationRate: "a-rate", defaultValue: 0,                         minValue: 0,    maxValue: 1 },

--- a/scripts/sound/worklets/PeakEQProcessor.js
+++ b/scripts/sound/worklets/PeakEQProcessor.js
@@ -2,7 +2,7 @@ class PeakEQProcessor extends AudioWorkletProcessor
 {
     static get parameterDescriptors() 
     {
-        const maxFreq = Math.min(sampleRate / 2.0, 20000.0);
+        const maxFreq = sampleRate * 0.45;
 
         return [
             { name: "bypass", automationRate: "a-rate", defaultValue: 0,                         minValue: 0,    maxValue: 1 },


### PR DESCRIPTION
- Caps the cutoff value of audio filters to 45% of the sample rate.
- Adds a missing call to `AudioEffectStruct.prototype.updateFreqDesc` to update the cap dynamically.
- Fixes an issue where initial parameter values of effects were not being registered as the format they were given to worklets in had been changed.
- Fixes an issue in the peak-eq effect where getters for every parameter would return the frequency.
- Relates to https://github.com/YoYoGames/GameMaker-Bugs/issues/1897.