### PR TITLE
Swap values of audio track loop mode constants

### DIFF
--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -72,8 +72,8 @@ eTT_Invisible = 1;
 eTT_Disable = 2;
 eTT_Count = 3;
 
-eSM_Loop = 0;
-eSM_Single = 1;
+eSM_Single = 0;
+eSM_Loop = 1;
 
 sRM_DirectAssign = 0;
 sRM_Lerp = 1;


### PR DESCRIPTION
Aligns loop mode constants with the version used by the IDE.

Relates to https://github.com/YoYoGames/GameMaker-Bugs/issues/6277.