### PR TITLE
Add HTTP connect timeout function stubs.

### DIFF
--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -45,6 +45,7 @@ var g_StartDateTime = Date.now();
 var g_CurrentTime = g_StartDateTime;
 var g_FrameStartTime = g_StartDateTime;
 var g_HttpRequestCrossOriginType = "anonymous";
+var g_HttpConnectTimeoutMs = 60000;
 
 //application surface...
 var g_ApplicationSurface =-1;

--- a/scripts/functions/Function_HTTP.js
+++ b/scripts/functions/Function_HTTP.js
@@ -510,3 +510,26 @@ function http_get_request_crossorigin()
 {
 	return g_HttpRequestCrossOriginType;
 }
+
+function http_set_connect_timeout(_connectTimeoutMs)
+{
+	/* NOTE: This is ignored in the HTML5 runner because there doesn't appear to be a way to
+	 * specify a timeout for the connection/handshaking part of a HTTP request.
+	 *
+	 * The XMLHttpRequest 'timeout' member enforces a maximum length of request, so it can't be
+	 * used to enforce a quick failure in the "server is down case" without also preventing any
+	 * kind of long-running request (e.g. downloading a big file).
+	*/
+
+	g_HttpConnectTimeoutMs = yyGetInt32(_connectTimeoutMs);
+
+	if(g_HttpConnectTimeoutMs <= 0)
+	{
+		g_HttpConnectTimeoutMs = 1;
+	}
+}
+
+function http_get_connect_timeout()
+{
+	return g_HttpConnectTimeoutMs;
+}


### PR DESCRIPTION
We don't actually use the supplied connection timeout in the HTML5 runner, becase as far as I can tell, there is no way to set a timeout specifically on the connection phase of an XmlHttpRequest.

The XmlHttpRequest 'timeout' member applies to the whole request, so it will cause a timeout while still actively streaming data.

https://github.com/YoYoGames/GameMaker-Bugs/issues/5744