### PR TITLE
GMB-6738: Fix depth buffer memory leak

### DIFF
--- a/scripts/functions/Function_Surface.js
+++ b/scripts/functions/Function_Surface.js
@@ -40,9 +40,13 @@ function surface_resize(_id, _w, _h)
 	// it'll happen at the start of the NEXT frame.
     if( _id == g_ApplicationSurface )
     {
-        g_NewApplicationSize = true;
-        g_NewApplicationWidth = _w;
-        g_NewApplicationHeight = _h;
+        if (g_ApplicationWidth != g_NewApplicationWidth
+            || g_NewApplicationHeight != g_NewApplicationHeight)
+        {
+            g_NewApplicationSize = true;
+            g_NewApplicationWidth = _w;
+            g_NewApplicationHeight = _h;
+        }
         return 1;
     }
 
@@ -60,15 +64,17 @@ function surface_resize(_id, _w, _h)
 
     //resize...
     var pSurf = g_Surfaces.Get(_id);
-    var format = eTextureFormat_A8R8G8B8;
-
-    if (g_webGL)
+    if (pSurf.m_Width != _w || pSurf.m_Height != _h)
     {
-        format = pSurf.texture.webgl_textureid.format;
-    }
-    
-    surface_create( _w,_h, format, _id );   //create new surface and replace existing in _id slot
+        var format = eTextureFormat_A8R8G8B8;
 
+        if (g_webGL)
+        {
+            format = pSurf.texture.webgl_textureid.format;
+        }
+
+        surface_create( _w,_h, format, _id );   //create new surface and replace existing in _id slot
+    }
     return 0;
 }
 

--- a/scripts/libWebGL/libWebGL.js
+++ b/scripts/libWebGL/libWebGL.js
@@ -2094,8 +2094,8 @@ function yyWebGL(_canvas, _options) {
         }
         gl.deleteTexture(_frameBuffer.Texture.Texture);
         if (_frameBuffer.textureDepth != null
-            && _frameBuffer.textureDepth.webgl_textureid instanceof yyGLTexture) {
-            gl.deleteTexture(_frameBuffer.textureDepth.webgl_textureid.Texture);
+            && _frameBuffer.textureDepth instanceof yyGLTexture) {
+            gl.deleteTexture(_frameBuffer.textureDepth.Texture);
         }
         
         // Make sure we ditch the reference to the wrapper to give the GC every chance to clean it up


### PR DESCRIPTION
`DeleteFramebuffer` was trying to free depth buffers using the wrong handle, so it never happened. This is now fixed. I've also added a check to `surface_resize` so it doesn't resize given surface if it already has the size speciifed, as that seems just wasteful.

Closes https://github.com/YoYoGames/GameMaker-Bugs/issues/6738
