### PR TITLE
Ensure `other` is changed when `self` is changed during exectution

### DIFF
--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -307,7 +307,7 @@ function method( _inst, _func )
                     // delete the other
                     newArgs.splice(1,1);
                     return this.func.apply(null, newArgs);
-                };              __yy_gml_object_create  
+                };
             }
             else {
                 newfunc = function() {

--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -165,7 +165,7 @@ function __yy_gml_object_create( _self, _a )
     var r = new GMLObject();
     var args = [];
     args[0] = r;
-    args[1] = _self;
+    args[1] = _a.boundObject ? _a.boundObject : _self;
     for( var n=2; n<arguments.length; ++n) {
         args[n] = arguments[n];
     } // end for
@@ -212,7 +212,7 @@ function is_handle( _v )
 }
 
 
-function __yyg_call_method( _func )
+function __yyg_call_method( _func, _self, _other )
 {
     switch( typeof(_func) )
     {
@@ -244,7 +244,8 @@ function __yy_method( _inst, _func )
     } else {
         var a = { func : _func, inst : _inst };
         var newfunc = function() {
-            var newArgs = Array.prototype.slice.call(arguments);        
+            var newArgs = Array.prototype.slice.call(arguments);    
+            newArgs[1] = newArgs[0];   
             newArgs[0] = this.inst;
             return this.func.apply(null, newArgs);
         };
@@ -279,6 +280,7 @@ function method( _inst, _func )
             var a = { func : _func, inst : _inst };
             var newfunc = function() {
                 var newArgs = Array.prototype.slice.call(arguments);
+                newArgs[1] = newArgs[0];   
                 newArgs[0] = this.inst;
                 return this.func.apply(null, newArgs);
             };        
@@ -305,7 +307,7 @@ function method( _inst, _func )
                     // delete the other
                     newArgs.splice(1,1);
                     return this.func.apply(null, newArgs);
-                };                
+                };              __yy_gml_object_create  
             }
             else {
                 newfunc = function() {


### PR DESCRIPTION
* When a method call is made and the `self` is changed to the bound struct then set `other` to be the previous `self`
* If `new` calls a constructor on a bound method then  ensure `other` is set to the bound `self`, otherwise it is the `self` from the new callsite.
* Address feature request - https://github.com/YoYoGames/GameMaker-Bugs/issues/7349
