### PR TITLE
audio_throw_on_error

### DIFF
--- a/scripts/Unsupported.js
+++ b/scripts/Unsupported.js
@@ -214,6 +214,10 @@ function audio_sync_group_is_playing()                  { ErrorFunction("audio_s
 function audio_sync_group_is_paused()                   { ErrorFunction("audio_sync_group_is_paused()"); return -1; }
 function audio_sync_group_debug()                       { ErrorFunction("audio_sync_group_debug()"); }
 
+/* Audio Debug */
+function audio_debug()                                  { ErrorFunction("audio_debug()"); }
+function audio_throw_on_error()                         { ErrorFunction("audio_throw_on_error()"); }
+
 function gpio_set()                                     { ErrorFunction("GPIO is not supported"); }
 function gpio_clear()                                   { ErrorFunction("GPIO is not supported"); }
 function gpio_get()                                     { ErrorFunction("GPIO is not supported"); return 0; }

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -2443,7 +2443,6 @@ function audio_get_listener_info(index)
     }
     return -1;
 }
-function audio_debug(trueFalse)                             {}
 
 // @if feature("audio")
 //loading -------------------------


### PR DESCRIPTION
- Marks `audio_debug` and `audio_throw_on_error` as unsupported on HTML5.
- Relates to https://github.com/YoYoGames/GameMaker-Bugs/issues/7285.