### PR TITLE
Clamp audio emitter falloff properties

### DIFF
--- a/scripts/sound/AudioEmitter.js
+++ b/scripts/sound/AudioEmitter.js
@@ -73,9 +73,9 @@ AudioEmitter.prototype.setBus = function(_bus) {
 };
 
 AudioEmitter.prototype.setFalloff = function(_falloffRef, _falloffMax, _falloffFactor) {
-    this.pannerNode.refDistance = _falloffRef;
-    this.pannerNode.maxDistance = _falloffMax;
-    this.pannerNode.rolloffFactor = _falloffFactor;
+    this.pannerNode.refDistance = Math.max(0, _falloffRef);
+    this.pannerNode.maxDistance = Math.max(Number.MIN_VALUE, _falloffMax);
+    this.pannerNode.rolloffFactor = Math.max(0, _falloffFactor);
     this.pannerNode.distanceModel = falloff_model;
 
     if (g_AudioFalloffModel === DistanceModels.AUDIO_FALLOFF_NONE) {


### PR DESCRIPTION
Limits the lower bounds of audio emitter ref distance, max distance and rolloff factor so as to not have the underlying `PannerNode` throw a `RangeError`.

Relates to https://github.com/YoYoGames/GameMaker-Bugs/issues/7698.