### PR TITLE
Audio stream/loop-end crashes

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3115,9 +3115,11 @@ function audio_create_stream(_filename)
 
     audio_sampledata[index] = sampleData;
 
+    const srcUrl = getUrlForSound(this.soundid);
+
     // Kick off a request to populate the asset duration
     const request = new XMLHttpRequest();
-    request.open("GET", getUrlForSound(index), true);
+    request.open("GET", srcUrl, true);
     request.responseType = "arraybuffer";
     request.onload = () => {
         if (request.status < 200 || request.status >= 300) {

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -673,8 +673,8 @@ audioSound.prototype.setLoopEnd = function(_offsetSecs) {
         return;
 
     const samplePeriod = 1.0 / g_WebAudioContext.sampleRate;
-    const duration = this.pbuffersource.buffer.duration;
-    const loopStart = this.pbuffersource.loopStart;
+    const duration = audio_sound_length(this.soundid);
+    const loopStart = this.loopStart;
 
     const minLoopEnd = (_offsetSecs <= 0.0) ? 0.0 : (loopStart + samplePeriod);
 


### PR DESCRIPTION
[**#7804:**](https://github.com/YoYoGames/GameMaker-Bugs/issues/7804)
- Fixes a reference to the undefined variable `srcUrl` in `audio_create_stream`.

[**#7805:**](https://github.com/YoYoGames/GameMaker-Bugs/issues/7805)
- Avoids referencing a voice's audio buffer when limiting loop bounds in `audioSound.prototype.setLoopEnd`, as it may not exist at this point if it is still being decoded.