### PR TITLE
Pass correct index to getUrlForSound

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3115,7 +3115,7 @@ function audio_create_stream(_filename)
 
     audio_sampledata[index] = sampleData;
 
-    const srcUrl = getUrlForSound(this.soundid);
+    const srcUrl = getUrlForSound(index);
 
     // Kick off a request to populate the asset duration
     const request = new XMLHttpRequest();


### PR DESCRIPTION
[**#7804**](https://github.com/YoYoGames/GameMaker-Bugs/issues/7804)
- Fixes an incorrect asset index being passed to `getUrlForSound` in `audio_create_stream`.