### PR TITLE
Audio pitch limits

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -1473,6 +1473,8 @@ function audio_sound_pitch(_soundid, _pitch)
 
     if (g_AudioModel != Audio_WebAudio)
         return;
+
+    _pitch = Math.max(0, _pitch);
     
 	if (_soundid >= BASE_SOUND_INDEX) {
         const voice = GetAudioSoundFromHandle(_soundid);

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -1476,7 +1476,7 @@ function audio_sound_pitch(_soundid, _pitch)
 
     _pitch = Math.max(0, _pitch);
     
-	if (_soundid >= BASE_SOUND_INDEX) {
+    if (_soundid >= BASE_SOUND_INDEX) {
         const voice = GetAudioSoundFromHandle(_soundid);
 
         if (voice === null)

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -1474,7 +1474,7 @@ function audio_sound_pitch(_soundid, _pitch)
     if (g_AudioModel != Audio_WebAudio)
         return;
 
-    _pitch = Math.max(0, _pitch);
+    _pitch = Math.max(Number.MIN_VALUE, _pitch);
     
     if (_soundid >= BASE_SOUND_INDEX) {
         const voice = GetAudioSoundFromHandle(_soundid);
@@ -2359,7 +2359,7 @@ function audio_emitter_pitch(_emitterIndex, _pitch) {
         return;
 
     _pitch = yyGetReal(_pitch);
-    _pitch = Math.max(0.0, _pitch);
+    _pitch = Math.max(Number.MIN_VALUE, _pitch);
 
     emitter.pitch = _pitch;
 

--- a/scripts/sound/AudioPlaybackProps.js
+++ b/scripts/sound/AudioPlaybackProps.js
@@ -32,7 +32,7 @@ function AudioPlaybackProps(_props) {
         this.offset = Math.max(0.0, this.offset);
 
     this.getProp(_props, "pitch", this, "pitch", true, yyGetReal, AudioPropsCalc.default_pitch);
-    this.pitch = Math.max(0.0, this.pitch);
+    this.pitch = Math.max(Number.MIN_VALUE, this.pitch);
 
     this.getProp(_props, "position", this, "position", true, undefined, undefined);
     if (typeof this.position === "object" && this.type === undefined) {

--- a/scripts/sound/AudioPropsCalc.js
+++ b/scripts/sound/AudioPropsCalc.js
@@ -31,13 +31,13 @@ AudioPropsCalc.CalcPitch = function(_voice) {
     const emitter = AudioPropsCalc.GetEmitterProps(_voice.pemitter);
 
     const sourcePitch = _voice.pitch * asset.pitch * emitter.pitch;
-	const clampedPitch = Math.min(Math.max(1 / 256, sourcePitch), 256);
+    const clampedPitch = Math.min(Math.max(1 / 256, sourcePitch), 256);
 
-	if (clampedPitch != sourcePitch) {
-		console.log("Warning: Source pitch was clipped to %f\n", clampedPitch);
-	}
+    if (clampedPitch != sourcePitch) {
+        console.log("Warning: Source pitch was clipped to %f\n", clampedPitch);
+    }
 
-	return clampedPitch;
+    return clampedPitch;
 };
 
 AudioPropsCalc.GetAssetProps = function(_asset_index) {

--- a/scripts/sound/AudioPropsCalc.js
+++ b/scripts/sound/AudioPropsCalc.js
@@ -30,7 +30,14 @@ AudioPropsCalc.CalcPitch = function(_voice) {
     const asset = AudioPropsCalc.GetAssetProps(_voice.soundid);
     const emitter = AudioPropsCalc.GetEmitterProps(_voice.pemitter);
 
-    return _voice.pitch * asset.pitch * emitter.pitch;
+    const sourcePitch = _voice.pitch * asset.pitch * emitter.pitch;
+	const clampedPitch = Math.min(Math.max(1 / 256, sourcePitch), 256);
+
+	if (clampedPitch != sourcePitch) {
+		console.log("Warning: Source pitch was clipped to %f\n", clampedPitch);
+	}
+
+	return clampedPitch;
 };
 
 AudioPropsCalc.GetAssetProps = function(_asset_index) {


### PR DESCRIPTION
[**#7319**](https://github.com/YoYoGames/GameMaker-Bugs/issues/7319)
- Makes sure that the pitch values passed into `audio_sound_pitch` and `audio_emitter_pitch`, and the playback functions are positive.
- Enforces clamping of the source pitch to between `1/256` and `256`.
- Prints a warning to the console if the source pitch is clamped.