### PR TITLE
Destroy call_later time sources on game restart / end

### DIFF
--- a/scripts/_GameMaker.js
+++ b/scripts/_GameMaker.js
@@ -1586,6 +1586,8 @@ function Run_EndGame(_reset) {
 	}
 	g_pInstanceManager.Clear();
 
+    g_SDTimeSourceParent.Destroy(g_SDTimeSourceParent);
+
 	// @if feature("audio")
     if (_reset) {
 		// Just stops all audio instances.


### PR DESCRIPTION
[**#7403**](https://github.com/YoYoGames/GameMaker-Bugs/issues/7403)
- Destroys the children of the `call_later` time source parent in `Run_EndGame`, which is run during `game_restart`.

Note that destroying a built-in time source is a shortcut to destroying all its child time sources, and does not destroy the built-in itself.