### PR TITLE
Loop clip warnings/abort stream requests

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -373,7 +373,8 @@ audioSound.prototype.Init = function(_props)
 	this.bStreamed = false;
 	this.bBuffered = false;
 	this.bQueued = false;
-    this.pgainnode.gain.value = AudioPropsCalc.CalcGain(this); 
+    this.pgainnode.gain.value = AudioPropsCalc.CalcGain(this);
+    this.request = undefined;
 	
 	if (this.soundid >= 0) {
 	    this.bStreamed = IsSoundStreamed(this.soundid);
@@ -495,6 +496,7 @@ audioSound.prototype.play = function() {
         };
 
         request.send();
+        this.request = request;
     }
     else {
         if (this.bQueued) {
@@ -533,6 +535,11 @@ audioSound.prototype.stop = function() {
 
     if (this.pgainnode !== null)
         this.pgainnode.disconnect();
+
+    if (this.request !== undefined) {
+        this.request.abort();
+        this.request = undefined;
+    }
 
     this.pemitter = null;
     this.bActive = false;


### PR DESCRIPTION
[**#8037**](https://github.com/YoYoGames/GameMaker-Bugs/issues/8037)
- Prints warnings if loop bounds were clipped either at the start/duration of the sound, or at the opposite bound.

[**#8121**](https://github.com/YoYoGames/GameMaker-Bugs/issues/8121)
- Aborts any pending `XMLHttpRequest` requests for audio data if a sound is stopped.