### PR TITLE
Use true loop-end value when setting loop bounds

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -406,7 +406,7 @@ audioSound.prototype.start = function(_buffer) {
         buffer: _buffer,
         loop: shouldLoop,
         loopStart: this.loopStart,
-        loopEnd: this.loopEnd,
+        loopEnd: trueLoopEnd,
         playbackRate: AudioPropsCalc.CalcPitch(this)
     };
 


### PR DESCRIPTION
[**#8160**](https://github.com/YoYoGames/GameMaker-Bugs/issues/8160)
- Uses the calculated 'true' loop-end bound as browsers seem to ignore a loop section with a zeroed loop-end (which is valid as per the Web Audio spec).