### PR TITLE
Empty audio queues

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3459,6 +3459,13 @@ function audio_create_play_queue(_format, _sampleRate, _channels)
         var scriptNode = newSound.scriptNode;
         var max_channels = outputBuffer.numberOfChannels;
 
+        if (scriptNode.sourceBuffers.length <= 0) {
+            const voice = audio_sounds.find(voice => voice.soundid === newSound.handle);
+            if (voice !== undefined) {
+                voice.stop();
+            }
+        }
+
         // put the data from the current buffer in there
         for (var sample = 0; sample < DYNAMIC_BUFFER_SIZE; sample++)
         {

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -607,7 +607,7 @@ audioSound.prototype.isPlaying = function() {
     if (this.bQueued) {
         var queued_sound = queue_sounds[this.soundid - BASE_QUEUE_SOUND_INDEX];
 
-        if (!queued_sound || !queued_sound.scriptNode || !queued_sound.scriptNode.onended) 
+        if (!queued_sound || !queued_sound.scriptNode || !queued_sound.scriptNode.onended || queued_sound.scriptNode.sourceBuffers.length <= 0) 
             return false;
 
         return true;

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3463,8 +3463,8 @@ function audio_create_play_queue(_format, _sampleRate, _channels)
             const voice = audio_sounds.find(voice => voice.soundid === newSound.handle);
             if (voice !== undefined) {
                 voice.stop();
-                return;
             }
+            return;
         }
 
         // put the data from the current buffer in there

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -503,6 +503,12 @@ audioSound.prototype.play = function() {
             const queue_id = this.soundid - BASE_QUEUE_SOUND_INDEX;
             const queueSound = queue_sounds[queue_id];
 
+            if (queueSound.scriptNode.sourceBuffers.length === 0) {
+                console.log("Error: Audio queue has no queued buffers");
+                this.bActive = false;
+                return;
+            }
+
             queueSound.gainnode = this.pgainnode;
 
             queueSound.scriptNode.connect(this.pgainnode);

--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3463,6 +3463,7 @@ function audio_create_play_queue(_format, _sampleRate, _channels)
             const voice = audio_sounds.find(voice => voice.soundid === newSound.handle);
             if (voice !== undefined) {
                 voice.stop();
+                return;
             }
         }
 


### PR DESCRIPTION
[**#37**](https://github.com/YoYoGames/GameMaker-Bugs/issues/37)
- Empty audio queues will now fail to play, while also printing an error message to the console.
- The underlying processing node of an audio queue should now disconnect once the queue has finished playing.
- Fixes an issue where the order that buffers were queued via `audio_queue_sound` was not necessarily the order that the buffers would be pushed to the queue, due to an intermediate async decoding process sometimes scrambling the order.