### PR TITLE
changed room_get_info to use "rotation" data for instances

### DIFF
--- a/scripts/functions/Function_Room.js
+++ b/scripts/functions/Function_Room.js
@@ -144,8 +144,11 @@ function room_get_info(_ind, _views, _instances, _layers, _layer_elements, _tile
             //unsafe fixes
 			inst.object_index = pObj.Name;
             inst.id = sourceInstance.id;
+                    
+                    //for some reason room instances now internally use the "rotation" variable, instead of angle
+                    variable_struct_set(inst, "angle", sourceInstance.rotation ? sourceInstance.rotation : 0);
+                    //variable_struct_set(inst, "angle", sourceInstance.angle ? sourceInstance.angle : 0);
 
-                    variable_struct_set(inst, "angle", sourceInstance.angle ? sourceInstance.angle : 0);
                     variable_struct_set(inst, "xscale", sourceInstance.scaleX ? sourceInstance.scaleX : 1);
                     variable_struct_set(inst, "yscale", sourceInstance.scaleY ? sourceInstance.scaleY : 1);
                     variable_struct_set(inst, "image_speed", sourceInstance.imageSpeed ? sourceInstance.imageSpeed : 1);


### PR DESCRIPTION
in runtime 2048.8.1.218
on web port angle wasn't being set as instance data uses "rotation" property for angle

just double checked to make sure, g_pRoomManager also uses "rotation" property