### PR TITLE
Audio/Texture group errors

### DIFF
--- a/scripts/functions/Function_Texture.js
+++ b/scripts/functions/Function_Texture.js
@@ -172,7 +172,9 @@ function draw_sprite_stretched(_pInst, _sprite, _sub_index, _x, _y, _w,_h)
 			if (!pTPE) {
 				console.log("Error: Texture page for " + pSpr.pName + " is not loaded");	
 			}
-	        Graphics_DrawStretchedExt(pSpr.ppTPE[image_index], yyGetReal(_x), yyGetReal(_y), yyGetReal(_w), yyGetReal(_h), 0xffffff, g_GlobalAlpha);
+			else {
+				Graphics_DrawStretchedExt(pTPE, yyGetReal(_x), yyGetReal(_y), yyGetReal(_w), yyGetReal(_h), 0xffffff, g_GlobalAlpha);
+			}
 	    }
 	}
 
@@ -316,7 +318,7 @@ function draw_sprite_part_ext(_pInst, _sprite, _sub_index, _left, _top, _width, 
 		}
 		else {
 			_color = ConvertGMColour(yyGetInt32(_color));
-        	Graphics_DrawPart(pSpr.ppTPE[image_index], yyGetReal(_left), yyGetReal(_top), yyGetReal(_width), yyGetReal(_height), yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), _color, yyGetReal(_alpha));
+        	Graphics_DrawPart(pTPE, yyGetReal(_left), yyGetReal(_top), yyGetReal(_width), yyGetReal(_height), yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), _color, yyGetReal(_alpha));
         	//Graphics_DrawGeneral(pSpr.ppTPE[_sub_index], _left, _top, _width, _height, _x, _y, _xscale, _yscale, 0, _color, _color, _color, _color, _alpha);
 		}
 	}
@@ -358,7 +360,7 @@ function draw_sprite_tiled(_pInst, _sprite, _sub_index, _x, _y) {
 			console.log("Error: Texture group for " + pSpr.pName + " is not loaded");
 		}
 		else {
-			Graphics_TextureDrawTiled( pSpr.ppTPE[image_index], yyGetReal(_x), yyGetReal(_y), 1,1, true, true, 0xffffff, g_GlobalAlpha);
+			Graphics_TextureDrawTiled(pTPE, yyGetReal(_x), yyGetReal(_y), 1,1, true, true, 0xffffff, g_GlobalAlpha);
 		}
     }
 }
@@ -404,7 +406,7 @@ function draw_sprite_tiled_ext(_pInst, _sprite,_sub_index,_x,_y,_xscale,_yscale,
 		}
 		else {
 			_color = ConvertGMColour(yyGetInt32(_color));
-        	Graphics_TextureDrawTiled( pSpr.ppTPE[image_index], yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), true, true, _color, _alpha);
+        	Graphics_TextureDrawTiled(pTPE, yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), true, true, _color, _alpha);
 		}
     }
 }

--- a/scripts/functions/Function_Texture.js
+++ b/scripts/functions/Function_Texture.js
@@ -126,7 +126,7 @@ function draw_sprite_pos(_pInst, _sprite, _sub_index, _x1, _y1, _x2,_y2, _x3,_y3
 		}
 		else {
 			_alpha = min(1.0, _alpha);
-        	pSpr.Sprite_DrawSimplePos(image_index, yyGetReal(_x1), yyGetReal(_y1), yyGetReal(_x2), yyGetReal(_y2), yyGetReal(_x3), yyGetReal(_y3), yyGetReal(_x4), yyGetReal(_y4), _alpha);
+			pSpr.Sprite_DrawSimplePos(image_index, yyGetReal(_x1), yyGetReal(_y1), yyGetReal(_x2), yyGetReal(_y2), yyGetReal(_x3), yyGetReal(_y3), yyGetReal(_x4), yyGetReal(_y4), _alpha);
 		}
 	}
 }
@@ -318,8 +318,8 @@ function draw_sprite_part_ext(_pInst, _sprite, _sub_index, _left, _top, _width, 
 		}
 		else {
 			_color = ConvertGMColour(yyGetInt32(_color));
-        	Graphics_DrawPart(pTPE, yyGetReal(_left), yyGetReal(_top), yyGetReal(_width), yyGetReal(_height), yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), _color, yyGetReal(_alpha));
-        	//Graphics_DrawGeneral(pSpr.ppTPE[_sub_index], _left, _top, _width, _height, _x, _y, _xscale, _yscale, 0, _color, _color, _color, _color, _alpha);
+			Graphics_DrawPart(pTPE, yyGetReal(_left), yyGetReal(_top), yyGetReal(_width), yyGetReal(_height), yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), _color, yyGetReal(_alpha));
+			//Graphics_DrawGeneral(pSpr.ppTPE[_sub_index], _left, _top, _width, _height, _x, _y, _xscale, _yscale, 0, _color, _color, _color, _color, _alpha);
 		}
 	}
 }
@@ -406,7 +406,7 @@ function draw_sprite_tiled_ext(_pInst, _sprite,_sub_index,_x,_y,_xscale,_yscale,
 		}
 		else {
 			_color = ConvertGMColour(yyGetInt32(_color));
-        	Graphics_TextureDrawTiled(pTPE, yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), true, true, _color, _alpha);
+			Graphics_TextureDrawTiled(pTPE, yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), true, true, _color, _alpha);
 		}
     }
 }

--- a/scripts/functions/Function_Texture.js
+++ b/scripts/functions/Function_Texture.js
@@ -119,8 +119,15 @@ function draw_sprite_pos(_pInst, _sprite, _sub_index, _x1, _y1, _x2,_y2, _x3,_y3
 	{
 		var sprite_frames = g_pSpriteManager.GetImageCount(_sprite);
 		var image_index = GetIndexFromImageIndex(_sub_index, sprite_frames);
-        _alpha = min(1.0, _alpha);
-        pSpr.Sprite_DrawSimplePos(image_index, yyGetReal(_x1), yyGetReal(_y1), yyGetReal(_x2), yyGetReal(_y2), yyGetReal(_x3), yyGetReal(_y3), yyGetReal(_x4), yyGetReal(_y4), _alpha);
+
+		const pTPE = pSpr.ppTPE[image_index];
+		if (!pTPE) {
+			console.log("Error: Texture group for " + pSpr.pName + " is not loaded");
+		}
+		else {
+			_alpha = min(1.0, _alpha);
+        	pSpr.Sprite_DrawSimplePos(image_index, yyGetReal(_x1), yyGetReal(_y1), yyGetReal(_x2), yyGetReal(_y2), yyGetReal(_x3), yyGetReal(_y3), yyGetReal(_x4), yyGetReal(_y4), _alpha);
+		}
 	}
 }
 
@@ -161,6 +168,10 @@ function draw_sprite_stretched(_pInst, _sprite, _sub_index, _x, _y, _w,_h)
 	    } else // ->
 		// @endif
 	    {
+			const pTPE = pSpr.ppTPE[image_index];
+			if (!pTPE) {
+				console.log("Error: Texture page for " + pSpr.pName + " is not loaded");	
+			}
 	        Graphics_DrawStretchedExt(pSpr.ppTPE[image_index], yyGetReal(_x), yyGetReal(_y), yyGetReal(_w), yyGetReal(_h), 0xffffff, g_GlobalAlpha);
 	    }
 	}
@@ -206,7 +217,13 @@ function    draw_sprite_stretched_ext( _pInst, _sprite, _sub_index, _x,_y, _w, _
 	    } else // ->
 		// @endif
 	    {
-	        Graphics_DrawStretchedExt(pSpr.ppTPE[image_index], yyGetReal(_x), yyGetReal(_y), yyGetReal(_w), yyGetReal(_h), ConvertGMColour(yyGetInt32(_colour)), yyGetReal(_alpha));
+			const pTPE = pSpr.ppTPE[image_index];
+			if (!pTPE) {
+				console.log("Error: Texture group for " + pSpr.pName + " is not loaded");
+			}
+			else {
+				Graphics_DrawStretchedExt(pTPE, yyGetReal(_x), yyGetReal(_y), yyGetReal(_w), yyGetReal(_h), ConvertGMColour(yyGetInt32(_colour)), yyGetReal(_alpha));
+			}
 	    }
 	}
     //draw_sprite_ext(_sprite,_sub_index,_x,_y,_xscale,_yscale,0,_colour, _alpha);
@@ -244,7 +261,13 @@ function draw_sprite_part(_pInst, _sprite, _sub_index, _left, _top, _width, _hei
 		var sprite_frames = g_pSpriteManager.GetImageCount(_sprite);
 		var image_index = GetIndexFromImageIndex(_sub_index, sprite_frames);
 
-	    Graphics_DrawPart(pSpr.ppTPE[image_index], yyGetReal(_left), yyGetReal(_top), yyGetReal(_width), yyGetReal(_height), yyGetReal(_x), yyGetReal(_y), 1, 1, 0xffffff, g_GlobalAlpha);
+		const pTPE = pSpr.ppTPE[image_index];
+		if (!pTPE) {
+			console.log("Error: Texture group for " + pSpr.pName + " is not loaded");
+		}
+		else {
+			Graphics_DrawPart(pTPE, yyGetReal(_left), yyGetReal(_top), yyGetReal(_width), yyGetReal(_height), yyGetReal(_x), yyGetReal(_y), 1, 1, 0xffffff, g_GlobalAlpha);
+		}
 	}
 }
 
@@ -287,10 +310,15 @@ function draw_sprite_part_ext(_pInst, _sprite, _sub_index, _left, _top, _width, 
 		var sprite_frames = g_pSpriteManager.GetImageCount(_sprite);
 		var image_index = GetIndexFromImageIndex(_sub_index, sprite_frames);
 
-
-        _color = ConvertGMColour(yyGetInt32(_color));
-        Graphics_DrawPart(pSpr.ppTPE[image_index], yyGetReal(_left), yyGetReal(_top), yyGetReal(_width), yyGetReal(_height), yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), _color, yyGetReal(_alpha));
-        //Graphics_DrawGeneral(pSpr.ppTPE[_sub_index], _left, _top, _width, _height, _x, _y, _xscale, _yscale, 0, _color, _color, _color, _color, _alpha);
+		const pTPE = pSpr.ppTPE[image_index];
+		if (!pTPE) {
+			console.log("Error: Texture group for " + pSpr.pName + " is not loaded");
+		}
+		else {
+			_color = ConvertGMColour(yyGetInt32(_color));
+        	Graphics_DrawPart(pSpr.ppTPE[image_index], yyGetReal(_left), yyGetReal(_top), yyGetReal(_width), yyGetReal(_height), yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), _color, yyGetReal(_alpha));
+        	//Graphics_DrawGeneral(pSpr.ppTPE[_sub_index], _left, _top, _width, _height, _x, _y, _xscale, _yscale, 0, _color, _color, _color, _color, _alpha);
+		}
 	}
 }
 
@@ -325,7 +353,13 @@ function draw_sprite_tiled(_pInst, _sprite, _sub_index, _x, _y) {
 		var sprite_frames = g_pSpriteManager.GetImageCount(_sprite);
 		var image_index = GetIndexFromImageIndex(_sub_index, sprite_frames);
     
-        Graphics_TextureDrawTiled( pSpr.ppTPE[image_index], yyGetReal(_x), yyGetReal(_y), 1,1, true, true, 0xffffff, g_GlobalAlpha);
+		const pTPE = pSpr.ppTPE[image_index];
+		if (!pTPE) {
+			console.log("Error: Texture group for " + pSpr.pName + " is not loaded");
+		}
+		else {
+			Graphics_TextureDrawTiled( pSpr.ppTPE[image_index], yyGetReal(_x), yyGetReal(_y), 1,1, true, true, 0xffffff, g_GlobalAlpha);
+		}
     }
 }
 
@@ -364,8 +398,14 @@ function draw_sprite_tiled_ext(_pInst, _sprite,_sub_index,_x,_y,_xscale,_yscale,
 		var sprite_frames = g_pSpriteManager.GetImageCount(_sprite);
 		var image_index = GetIndexFromImageIndex(_sub_index, sprite_frames);
     
-        _color = ConvertGMColour(yyGetInt32(_color));
-        Graphics_TextureDrawTiled( pSpr.ppTPE[image_index], yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), true, true, _color, _alpha);
+		const pTPE = pSpr.ppTPE[image_index];
+		if (!pTPE) {
+			console.log("Error: Texture group for " + pSpr.pName + " is not loaded");
+		}
+		else {
+			_color = ConvertGMColour(yyGetInt32(_color));
+        	Graphics_TextureDrawTiled( pSpr.ppTPE[image_index], yyGetReal(_x), yyGetReal(_y), yyGetReal(_xscale), yyGetReal(_yscale), true, true, _color, _alpha);
+		}
     }
 }
 
@@ -422,7 +462,14 @@ function draw_sprite_general(_pInst, _sprite, _sub_index, _left, _top, _width, _
         _c2 = ConvertGMColour(yyGetInt32(_c2));
         _c3 = ConvertGMColour(yyGetInt32(_c3));
         _c4 = ConvertGMColour(yyGetInt32(_c4));
-        Graphics_DrawGeneral(pSpr.ppTPE[image_index], yyGetReal(_left),yyGetReal(_top),yyGetReal(_width),yyGetReal(_height),    yyGetReal(_x),yyGetReal(_y),yyGetReal(_xscale),yyGetReal(_yscale),  yyGetReal(_rot) * Math.PI / 180.0,  _c1,_c2,_c3,_c4,  yyGetReal(_alpha));
+
+		const pTPE = pSpr.ppTPE[image_index];
+		if (!pTPE) {
+			console.log("Error: Texture group for " + pSpr.pName + " is not loaded");
+		}
+		else {
+			Graphics_DrawGeneral(pTPE, yyGetReal(_left),yyGetReal(_top),yyGetReal(_width),yyGetReal(_height), yyGetReal(_x),yyGetReal(_y),yyGetReal(_xscale),yyGetReal(_yscale),  yyGetReal(_rot) * Math.PI / 180.0,  _c1,_c2,_c3,_c4,  yyGetReal(_alpha));
+		}
 	}
 }
 

--- a/scripts/sound/AudioPlaybackProps.js
+++ b/scripts/sound/AudioPlaybackProps.js
@@ -81,7 +81,7 @@ AudioPlaybackProps.prototype.invalid = function() {
     }
 
     if (!audio_group_is_loaded(this.asset.groupId)) {
-        debug(audio_get_name(this.asset_index) + ": Audio Group " + this.asset.groupId + " is not loaded");
+        debug("Error: Audio group for " + audio_get_name(this.asset_index) + " (" + this.asset.groupId + ") is not loaded");
         return true;
     }
 

--- a/scripts/yySprite.js
+++ b/scripts/yySprite.js
@@ -1514,8 +1514,8 @@ yySprite.prototype.Draw = function (_ind, _x, _y, _xscale, _yscale, _angle, _col
 				console.log("Error: Texture group for " + this.pName + " is not loaded");
 			}
 			else {
-		    	// undefined forces colour+alpha into ALL verts
-		    	Graphics_TextureDraw(pTPE, this.xOrigin, this.yOrigin, _x, _y, _xscale, _yscale, _angle * Math.PI / 180.0, _colour, undefined, undefined, undefined, _alpha);
+				// undefined forces colour+alpha into ALL verts
+				Graphics_TextureDraw(pTPE, this.xOrigin, this.yOrigin, _x, _y, _xscale, _yscale, _angle * Math.PI / 180.0, _colour, undefined, undefined, undefined, _alpha);
 			}
 		}
 	}

--- a/scripts/yySprite.js
+++ b/scripts/yySprite.js
@@ -1421,7 +1421,10 @@ yySprite.prototype.DrawSimple = function (_sub_image, _x, _y, _alpha) {
 		if (!this.ppTPE) return;
         // Make sure we're not dealing with a texture that's been downsized to fit the tpage
         var pTPE = this.ppTPE[_sub_image];
-        if (!pTPE) return; // no loaded? texture group etc?
+        if (!pTPE) { // no loaded? texture group etc?
+			console.log("Error: Texture page for " + this.pName + " is not loaded");
+			return;
+		}
 		
 		// @if feature("nineslice")
         if ((this.nineslicedata != null) && (this.nineslicedata.enabled == true))
@@ -1506,8 +1509,14 @@ yySprite.prototype.Draw = function (_ind, _x, _y, _xscale, _yscale, _angle, _col
 		} else // ->
 		// @endif
 		{
-		    // undefined forces colour+alpha into ALL verts
-		    Graphics_TextureDraw(this.ppTPE[_ind], this.xOrigin, this.yOrigin, _x, _y, _xscale, _yscale, _angle * Math.PI / 180.0, _colour, undefined, undefined, undefined, _alpha);
+			const pTPE = this.ppTPE[_ind];
+			if (!pTPE) {
+				console.log("Error: Texture group for " + this.pName + " is not loaded");
+			}
+			else {
+		    	// undefined forces colour+alpha into ALL verts
+		    	Graphics_TextureDraw(pTPE, this.xOrigin, this.yOrigin, _x, _y, _xscale, _yscale, _angle * Math.PI / 180.0, _colour, undefined, undefined, undefined, _alpha);
+			}
 		}
 	}
 };


### PR DESCRIPTION
[**#235**](https://github.com/YoYoGames/GameMaker-Bugs/issues/235)
- Prints an error to the console if the sprite to be drawn is from an unloaded texture page.
- Aligns the error message for playing from an unloaded audio group with the main runner.
- Also fixes https://github.com/YoYoGames/GameMaker-Bugs/issues/8371