### PR TITLE
GMB-7100: Fix surface_set_texture giving errors when setting a surface with no depth buffer

### DIFF
--- a/scripts/functions/Function_Surface.js
+++ b/scripts/functions/Function_Surface.js
@@ -578,8 +578,10 @@ function surface_set_target_RELEASE(_id, _depth_id)
 
     if (g_webGL) {
         g_CurrentFrameBuffer = pSurf.FrameBuffer;
+        var hasDepthTexture = (pSurfDepth.textureDepth != null
+            && pSurfDepth.textureDepth.webgl_textureid instanceof yyGLTexture);
         g_CurrentDepthBuffer = g_SupportDepthTexture
-            ? pSurfDepth.textureDepth.webgl_textureid.Texture
+            ? (hasDepthTexture ? pSurfDepth.textureDepth.webgl_textureid.Texture : null)
             : pSurfDepth.FrameBufferData.RenderBuffer;
         g_webGL.SetRenderTarget(g_CurrentFrameBuffer, g_CurrentDepthBuffer);
         g_RenderTargetActive = -1;


### PR DESCRIPTION
Closes: https://github.com/YoYoGames/GameMaker-Bugs/issues/7100
