### PR TITLE
Ensure that self is passed in for predicate functions for static binding situations.

### DIFF
--- a/scripts/functions/Function_File.js
+++ b/scripts/functions/Function_File.js
@@ -1297,12 +1297,12 @@ function json_encode(_map, _prettify) {
 
 // This is an any to JSON helper function (to be used before JSON.stringify)
 var g_JSON_gml_infunc = undefined;
-function _json_replacer(key, value) 
+function _json_replacer(_selfinst, key, value) 
 {
 	// call the user method
 	if ((g_JSON_gml_infunc != undefined) && is_callable(g_JSON_gml_infunc)) {
 	    var _func = getFunction(g_JSON_gml_infunc, 1);
-	    _obj = "boundObject" in _func ? _func.boundObject : {};
+	    _obj = _func.boundObject : _selfinst;
 		value = _func(_obj, _obj, key, value);
 	} // end if
 
@@ -1342,7 +1342,7 @@ function _json_replacer(key, value)
 
 				var ret = [];
 				value.forEach( (item, index) => {
-					ret.push(_json_replacer(index.toString(), item));
+					ret.push(_json_replacer(_selfinst, index.toString(), item));
 				});
 
 				// Remove the flag
@@ -1379,7 +1379,7 @@ function _json_replacer(key, value)
 
 						if ((entry == undefined) || (entry[0] | entry[1])) {
 							Object.defineProperty( ret, name, { 
-								value : _json_replacer(name, value[oName]),
+								value : _json_replacer(_selfinst, name, value[oName]),
 								configurable : true,
 								writable : true,
 								enumerable : true
@@ -1400,7 +1400,7 @@ function _json_replacer(key, value)
 	}
 } // end _json_replacer
 
-function json_stringify( _v, _prettify, filter )
+function json_stringify( _selfinst, _v, _prettify, filter )
 {
 	try {
 		// Check if we want to prettify the output string
@@ -1413,7 +1413,7 @@ function json_stringify( _v, _prettify, filter )
 
 		var prevFunc = g_JSON_gml_infunc;
 		g_JSON_gml_infunc = filter;
-		var _struct = _json_replacer( "", _v);		
+		var _struct = _json_replacer( _selfinst, "", _v);		
 		g_JSON_gml_infunc = prevFunc;
 		return JSON.stringify(_struct, null, _prettify ? 2 : 0);
 	}
@@ -1426,8 +1426,9 @@ function json_stringify( _v, _prettify, filter )
 
 // This is a JSON to any helper function (to be used with JSON.parse)
 var g_JSON_gml_func = undefined;
+var g_JSON_gml_selfinst = undefined;
 var g_counterPointerNull = 0;
-function _json_reviver(_, value) 
+function _json_reviver( _, value) 
 {
 	var ret = undefined;
 	switch (typeof value) {
@@ -1511,7 +1512,7 @@ function _json_reviver(_, value)
 	// call the user method
 	if ((g_JSON_gml_func != undefined) && is_callable(g_JSON_gml_func)) {
 	    var _func = getFunction(g_JSON_gml_func, 1);
-	    _obj = "boundObject" in _func ? _func.boundObject : {};
+	    _obj = _func.boundObject ?? g_JSON_gml_selfinst;
 	    if (ret == g_pBuiltIn.pointer_null) {
 	    	ret = undefined;
 			--g_counterPointerNull;
@@ -1553,12 +1554,14 @@ function json_convert_pointer_null( _v )
 	return ret;
 }
 
-function json_parse( _v, _func )
+function json_parse( _selfinst, _v, _func )
 {
 	var ret = undefined;
 	var oldFunc = g_JSON_gml_func;
+	var oldSelf = g_JSON_gml_selfinst;
 	var oldCounter = g_counterPointerNull;
 	g_JSON_gml_func = _func;
+	g_JSON_gml_selfinst = _selfinst;
 	g_counterPointerNull = 0;
 	try {
 		var ret = JSON.parse(_v, _json_reviver);	
@@ -1573,6 +1576,7 @@ function json_parse( _v, _func )
 	}
 	g_counterPointerNull = oldCounter;
 	g_JSON_gml_func = oldFunc;
+	g_JSON_gml_selfinst = oldSelf;
 	return ret;
 } // end json_parse
 

--- a/scripts/functions/Function_String.js
+++ b/scripts/functions/Function_String.js
@@ -1384,13 +1384,13 @@ function __yy_CharCodeSize(_code) {
     return (_code >= 0xD800 && _code <= 0xD8FF) ? 2 : 1;
 }
 
-function string_foreach(_str, _func, _pos, _length) {
+function string_foreach(_selfinst, _str, _func, _pos, _length) {
 
     _str = yyGetString(_str);
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _pos = _pos != undefined ? yyGetReal(_pos) : 1;

--- a/scripts/functions/collections/ds_grid.js
+++ b/scripts/functions/collections/ds_grid.js
@@ -1994,7 +1994,7 @@ function ds_grid_sort(_id, _column, _ascending) {
 ///          	Convert a ds_grid into a mp_grid (of the same size)
 ///          </summary>
 // #############################################################################################
-function ds_grid_to_mp_grid(_src, _dest, _predicate) {
+function ds_grid_to_mp_grid(_selfinst, _src, _dest, _predicate) {
 
     var pGrid = g_ActiveGrids.Get(yyGetInt32(_src));
     var pMPGrid = g_MPGridColletion.Get(yyGetInt32(_dest));
@@ -2035,14 +2035,14 @@ function ds_grid_to_mp_grid(_src, _dest, _predicate) {
 	{
 		// Check method argument
 		_func = getFunction(_predicate, 2);
-		_obj = "boundObject" in _func ? _func.boundObject : {};
+		_obj =  _func.boundObject ?? _selfinst;
 
 		for (var y = 0; y < h; ++y)
 		{
 			for (var x = 0; x < w; ++x)
 			{
 				var val = pGrid.m_pGrid[x + (y * pGrid.m_Width)];
-				var res = yyGetBool(_func(_obj, _obj, val, x, y));
+				var res = yyGetBool(_func(_selfinst, _obj, _obj, val, x, y));
 
 				pMPGrid.m_cells[(x * pMPGrid.m_vcells) + y] = res ? -1 : 0;
 			}

--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -751,7 +751,7 @@ function array_delete( _array, _index, _number )
     } // end else
 } // end array_delete
 
-function array_sort( _array, _typeofSort )
+function array_sort( _selfinst, _array, _typeofSort )
 {
     if (Array.isArray(_array)) {
 
@@ -763,12 +763,7 @@ function array_sort( _array, _typeofSort )
             case "number":
                 var func = JSON_game.Scripts[_typeofSort - 100000];
                 var obj;
-                if ( "boundObject" in func) {
-                    obj = func.boundObject;
-                } // end if
-                else {
-                    obj = {};
-                } // end else
+                obj = func.boundObject ?? _selfinst;
                 _array.sort(function(a,b) { return func( obj, obj, a, b); } );
                 break;
             default:
@@ -878,14 +873,14 @@ function array_last(_array) {
     return _length == 0 ? undefined : _array[_length -1];
 } // end array_last
 
-function array_create_ext(_size, _func) {
+function array_create_ext(_selfinst, _size, _func) {
 
     // Check size argument
     _size = _size === undefined ? 0 : yyGetReal(_size);
     
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     var ret = new Array(_size);
     for (var i = 0; i < _size; i++) {
@@ -903,7 +898,7 @@ function array_find_index(_array, _func, _offset, _length) {
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
@@ -1052,14 +1047,14 @@ function array_contains_ext(_array, _values, _matchAll, _offset, _length) {
     return false;
 } // end array_contains_ext
 
-function array_any(_array, _func, _offset, _length) {
+function array_any(_selfinst, _array, _func, _offset, _length) {
 
     // Check array argument
     if (!Array.isArray(_array)) yyError("array_any : argument0 is not an array");
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
@@ -1088,14 +1083,14 @@ function array_any(_array, _func, _offset, _length) {
     return false;
 } // end array_any
 
-function array_all(_array, _func, _offset, _length) {
+function array_all(_selfinst, _array, _func, _offset, _length) {
 
     // Check array argument
     if (!Array.isArray(_array)) yyError("array_all : argument0 is not an array");
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
@@ -1124,18 +1119,18 @@ function array_all(_array, _func, _offset, _length) {
     return true;
 } // end array_all
 
-function array_foreach(_array, _func, _offset, _length) {
+function array_foreach(_selfinst, _array, _func, _offset, _length) {
 
     // Check array argument
     if (!Array.isArray(_array)) yyError("array_foreach : argument0 is not an array");
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
-    _length = arguments.length > 3 ? yyGetReal(_length) : _array.length; 
+    _length = arguments.length > 5 ? yyGetReal(_length) : _array.length; 
 
     // Compute raw values into valid/clamped values
     _itValues = computeIterationValues(_array.length, _offset, _length); // [offset, loops, step]
@@ -1155,14 +1150,14 @@ function array_foreach(_array, _func, _offset, _length) {
     }
 } // end array_foreach
 
-function array_reduce(_array, _func, _init, _offset, _length) {
+function array_reduce(_selfinst, _array, _func, _init, _offset, _length) {
 
     // Check array argument
     if (!Array.isArray(_array)) yyError("array_reduce : argument0 is not an array");
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
@@ -1196,14 +1191,14 @@ function array_reduce(_array, _func, _init, _offset, _length) {
     return _init;
 } // end array_reduce
 
-function array_filter(_array, _func, _offset, _length) {
+function array_filter(_selfinst, _array, _func, _offset, _length) {
 
     // Check array argument
     if (!Array.isArray(_array)) yyError("array_filter : argument0 is not an array");
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
@@ -1235,14 +1230,14 @@ function array_filter(_array, _func, _offset, _length) {
     return _ret;
 } // end array_filter
 
-function array_filter_ext(_array, _func, _offset, _length) {
+function array_filter_ext(_selfinst, _array, _func, _offset, _length) {
 
     // Check array argument
     if (!Array.isArray(_array)) yyError("array_filter_ext : argument0 is not an array");
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
@@ -1275,14 +1270,14 @@ function array_filter_ext(_array, _func, _offset, _length) {
     return _ret;
 } // end array_filter_ext
 
-function array_map(_array, _func, _offset, _length) {
+function array_map(_selfinst, _array, _func, _offset, _length) {
 
     // Check array argument
     if (!Array.isArray(_array)) yyError("array_map : argument0 is not an array");
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
@@ -1312,14 +1307,14 @@ function array_map(_array, _func, _offset, _length) {
     return _ret;
 } // end array_map
 
-function array_map_ext(_array, _func, _offset, _length) {
+function array_map_ext(_selfinst, _array, _func, _offset, _length) {
 
     // Check array argument
     if (!Array.isArray(_array)) yyError("array_map_ext : argument0 is not an array");
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
@@ -1349,14 +1344,14 @@ function array_map_ext(_array, _func, _offset, _length) {
     return _ret;
 } // end array_map_ext
 
-function array_copy_while(_array, _func, _offset, _length) {
+function array_copy_while(_selfinst, _array, _func, _offset, _length) {
 
     // Check array argument
     if (!Array.isArray(_array)) yyError("array_copy_while : argument0 is not an array");
 
     // Check method argument
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     // Check raw offset and length
     _offset = _offset != undefined ? yyGetReal(_offset) : 0;
@@ -2767,10 +2762,10 @@ function struct_remove( _id, _var)
 } // end struct_remove
 
 // struct_foreach(id, func)
-function struct_foreach(_id, _func) {
+function struct_foreach(_selfinst, _id, _func) {
 
     _func = getFunction(_func, 1);
-    _obj = "boundObject" in _func ? _func.boundObject : {};
+    _obj = _func.boundObject ?? _selfinst;
 
     var pObj = null;
     var glob = false;


### PR DESCRIPTION
* Fix bug https://github.com/YoYoGames/GameMaker-Bugs/issues/8903
* Updates the following functions to include a self parameter NOTE: compiler will automatically add that.
```
ds_grid_to_mp_grid
json_stringify
json_parse
array_sort
array_create_ext
array_find_index
array_any
array_all
array_foreach
array_reduce
array_filter
array_filter_ext
array_map
array_map_ext
struct_foreach
string_foreach
```



