### PR TITLE
Fix for https://github.com/YoYoGames/GameMaker-Bugs/issues/8058

### DIFF
--- a/scripts/yyFont.js
+++ b/scripts/yyFont.js
@@ -2000,7 +2000,10 @@ yyFontManager.prototype.Split_TextBlock_IDEstyle = function (_pStr, _boundsWidth
 		{
 			textLines[textLines.length] = pNew.substring(start, char);
 
-			while((pNew[char] == newline) || (pNew[char] == newline2))
+			var thechar = pNew[char];
+			char++;
+
+			if (((pNew[char] == newline) || (pNew[char] == newline2)) && (pNew[char] != thechar))			
 			{
 				char++;
 			}

--- a/scripts/yyFont.js
+++ b/scripts/yyFont.js
@@ -2003,7 +2003,7 @@ yyFontManager.prototype.Split_TextBlock_IDEstyle = function (_pStr, _boundsWidth
 			var thechar = pNew[char];
 			char++;
 
-			if (((pNew[char] == newline) || (pNew[char] == newline2)) && (pNew[char] != thechar))			
+			if ((char < len) && ((pNew[char] == newline) || (pNew[char] == newline2)) && (pNew[char] != thechar))			
 			{
 				char++;
 			}


### PR DESCRIPTION
The HTML5 runner now uses the same logic as the C++ runner when splitting IDE-placed text blocks on newline characters (successive newline characters are now treated as paragraph breaks).