### PR TITLE
Fix syntax err in _json_replacer

### DIFF
--- a/scripts/functions/Function_File.js
+++ b/scripts/functions/Function_File.js
@@ -1302,7 +1302,7 @@ function _json_replacer(_selfinst, key, value)
 	// call the user method
 	if ((g_JSON_gml_infunc != undefined) && is_callable(g_JSON_gml_infunc)) {
 	    var _func = getFunction(g_JSON_gml_infunc, 1);
-	    _obj = _func.boundObject : _selfinst;
+	    const _obj = "boundObject" in _func ? _func.boundObject : _selfinst;
 		value = _func(_obj, _obj, key, value);
 	} // end if
 

--- a/scripts/functions/Function_File.js
+++ b/scripts/functions/Function_File.js
@@ -1302,7 +1302,7 @@ function _json_replacer(_selfinst, key, value)
 	// call the user method
 	if ((g_JSON_gml_infunc != undefined) && is_callable(g_JSON_gml_infunc)) {
 	    var _func = getFunction(g_JSON_gml_infunc, 1);
-	    const _obj = "boundObject" in _func ? _func.boundObject : _selfinst;
+	    const _obj = (_func.boundObject !== null && _func.boundObject !== undefined) ? _func.boundObject : _selfinst;
 		value = _func(_obj, _obj, key, value);
 	} // end if
 


### PR DESCRIPTION
[**#8903**](https://github.com/YoYoGames/GameMaker-Bugs/issues/8903)
- Fixes a syntax error in `_json_replacer` (see the original change [here](https://github.com/YoYoGames/GameMaker-HTML5/pull/590/files#diff-99749782c2d36d5056cb809f073fe5d6468fed12afe8521032eb6c0a17d3def7R1305)).