### PR TITLE
Collision test would return `-1` instead of `noone` when not colliding

### DIFF
--- a/scripts/functions/Function_Instance.js
+++ b/scripts/functions/Function_Instance.js
@@ -1264,7 +1264,7 @@ function PerformColTest(_selfinst,_x,_y,_obj)
 					return id;
 			}
 		}
-		return -1;
+		return OBJECT_NOONE;
 	}
 	else
 	{


### PR DESCRIPTION
Closes: https://github.com/YoYoGames/GameMaker-Bugs/issues/9222