### PR TITLE
Implement time ramped gain for audio emitters (FR #9386)

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -108,6 +108,7 @@ function audio_update()
         return;
 
     // Update and apply gains
+    audio_emitters.forEach(_emitter => _emitter.updateGain());
     g_AudioGroups.forEach(_group => _group.gain.update());
     audio_sampledata.forEach(_asset => {
         if (_asset != null) {
@@ -1557,7 +1558,7 @@ function audio_sound_get_gain(_index)
     return 0;
 }
 
-function audio_sound_gain(_index, _gain, _timeMs)
+function audio_sound_gain(_index, _gain, _timeMs = 0)
 {
     _index = yyGetInt32(_index);
 
@@ -2398,17 +2399,17 @@ function audio_get_master_gain( _listenerId )
 }
 
 /* Sets the gain of an emitter. Also updates any voices playing on the emitter. */
-function audio_emitter_gain(_emitterIndex, _gain) {
+function audio_emitter_gain(_emitterIndex, _gain, _timeMs = 0) {
     const emitter = Audio_GetEmitterOrThrow(_emitterIndex);
 
     if (emitter === undefined)
         return;
 
     _gain = yyGetReal(_gain);
-    _gain = Math.max(0.0, _gain);
+    _timeMs = yyGetInt32(_timeMs);
 
     /* Voice gain is updated in audio_update() */
-    emitter.gainnode.gain.value = _gain;
+    emitter.setGain(_gain, _timeMs);
 }
 
 /* Retrieves the gain of an emitter. */
@@ -2418,7 +2419,7 @@ function audio_emitter_get_gain(_emitterIndex) {
     if (emitter === undefined)
         return 0.0;
 
-    return emitter.gainnode.gain.value;
+    return emitter.getGain();
 }
 
 /* Sets the pitch of an emitter. Also updates any voices playing on the emitter. */
@@ -3097,7 +3098,7 @@ function audio_group_stop_all( _groupId )
     audio_group_stop_sounds( yyGetInt32(_groupId) );
 }
 
-function audio_group_set_gain(_groupId, _gain, _timeMs)
+function audio_group_set_gain(_groupId, _gain, _timeMs = 0)
 {
     _groupId = yyGetInt32(_groupId);
     _gain = yyGetReal(_gain);

--- a/scripts/sound/AudioEmitter.js
+++ b/scripts/sound/AudioEmitter.js
@@ -6,6 +6,7 @@ class AudioEmitter {
             return null;
         }
         
+        this.gainramp = new TimeRampedParamLinear(1);
         this.gainnode = Audio_CreateGainNode(g_WebAudioContext);
         this.pannerNode = AudioEmitter.createPannerNode();
         this.pannerNode.connect(this.gainnode);
@@ -36,6 +37,7 @@ AudioEmitter.prototype.reset = function() {
     this.pannerNode.distanceModel = falloff_model;
     this.pannerNode.panningModel = "equalpower";
 
+    this.gainramp.set(1.0);
     this.gainnode.gain.value = 1.0;
 
     g_AudioBusMain.connectInput(this.gainnode);
@@ -100,5 +102,25 @@ AudioEmitter.prototype.setPosition = function(_x, _y, _z) {
     this.pannerNode.positionX.value = _x;
     this.pannerNode.positionY.value = _y;
     this.pannerNode.positionZ.value = _z;
+};
+
+AudioEmitter.prototype.getGain = function() {
+    return this.gainramp.get();
+};
+
+AudioEmitter.prototype.updateGain = function() {
+    this.gainramp.update();
+    if (this.gainnode)
+        this.gainnode.gain.value = this.gainramp.get();
+};
+
+AudioEmitter.prototype.setGain = function(_gain, _timeMs = 0) {
+    _gain = Math.max(0, _gain);
+    _timeMs = Math.max(0, _timeMs);
+
+    this.gainramp.set(_gain, _timeMs);
+
+    if (_timeMs === 0)
+        this.updateGain();
 };
 // @endif audio

--- a/scripts/sound/AudioPropsCalc.js
+++ b/scripts/sound/AudioPropsCalc.js
@@ -61,7 +61,7 @@ AudioPropsCalc.GetAssetProps = function(_asset_index) {
 AudioPropsCalc.GetEmitterProps = function(_emitter) {
     if (_emitter != null) {
         return (() => ({
-            gain: _emitter.gainnode.gain.value,
+            gain: _emitter.getGain(),
             pitch: _emitter.pitch
         }))();
     }

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -5742,7 +5742,7 @@ yySequenceManager.prototype.HandleAudioTrackUpdate = function (_pEl, _pSeq, _pIn
 
                         if (pAudioInfo.soundindex != -1 && audio_emitter_exists(pAudioInfo.emitterindex) === true)
                         {
-                            audio_emitter_gain(pAudioInfo.emitterindex, gain);
+                            audio_emitter_gain(pAudioInfo.emitterindex, gain, 0);
                             audio_emitter_pitch(pAudioInfo.emitterindex, pitch);
                             audio_emitter_falloff(pAudioInfo.emitterindex, falloffRef, falloffMax, falloffFac);
 


### PR DESCRIPTION
Corresponding C++ PR: https://github.com/GameMakerEnterprise/GMS2-Runner-Main/pull/23
Corresponding Feature Request: https://github.com/YoYoGames/GameMaker-Bugs/issues/9386

I did not test this particular PR very thoroughly as I don't have much JS experience, but my own "emittertest" demo YYP seems to behave as expected and the emitter gain seems to ramp correctly just like with the C++ PR.
Any feedback is appreciated!

(cc toby-yoyo?)