### PR TITLE
Use correct effect script name supplied by asset compiler.

### DIFF
--- a/scripts/yyEffects.js
+++ b/scripts/yyEffects.js
@@ -116,7 +116,7 @@ yyEffectInfo.prototype.SetupFromJson = function (_json)
 
 	if(this.type == FAE_TYPE_EFFECT)
 	{
-		this.pScriptOrShaderName = jsonObj.name;
+		this.pScriptOrShaderName = jsonObj.scriptname;
 	}
 	else
 	{


### PR DESCRIPTION
Scripts are now namespaced by the project (e.g. prefab) they are sourced from, so the correct script name gets injected into the JSON.

https://github.com/YoYoGames/GameMaker-Bugs/issues/9886