### PR TITLE
Reversed the `layer_destroy_instances` loop so we don't skip elements

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -2432,7 +2432,7 @@ function layer_destroy_instances(arg1)
 
     if(pLayer!=null)
     {
-        for(var i = 0; i < pLayer.m_elements.length; i++)
+        for(var i = pLayer.m_elements.length - 1; i >= 0; --i)
         {
             var el = pLayer.m_elements.Get(i);
             if (el != null)


### PR DESCRIPTION
Closes: https://github.com/YoYoGames/GameMaker-Bugs/issues/10470