### PR TITLE
Workaround obfuscator failing to recognise a known fn

### DIFF
--- a/scripts/sound/AudioPropsCalc.js
+++ b/scripts/sound/AudioPropsCalc.js
@@ -61,7 +61,7 @@ AudioPropsCalc.GetAssetProps = function(_asset_index) {
 AudioPropsCalc.GetEmitterProps = function(_emitter) {
     if (_emitter != null) {
         return (() => ({
-            gain: _emitter.getGain(),
+            gain: _emitter.gainramp.get(),
             pitch: _emitter.pitch
         }))();
     }


### PR DESCRIPTION
[**GM-4903**](https://github.com/YoYoGames/GameMaker/issues/4903)
The obfuscator fails to recognise one particular call to `AudioEmitter.prototype.getGain` as being a reference to the same function as others it has obfuscated. This leads it to obfuscating this call with a new identifier which ends up being different to the function definition itself, leading to a `TypeError` being thrown when it is called at runtime.

The nature of this issue prevents it from being resolved by adding the function to the obfuscator's exceptions list, so the function has been inlined in this one particular location.