### PR TITLE
Fix mouse_clear() button handling.

### DIFF
--- a/scripts/functions/Function_IO.js
+++ b/scripts/functions/Function_IO.js
@@ -200,11 +200,7 @@ function mouse_clear( _button )
         mouse_clear(2);
         mouse_clear(3);
     } else if (_button >= 1 && _button <= 3) {
-        var i = _button - 1;
-        g_pIOManager.ButtonDown[i] = 0;
-        g_pIOManager.ButtonPressed[i] = 0;
-        g_pIOManager.ButtonReleased[i] = 0;
-        g_EventButtons &= ~(1 << i);
+        g_pIOManager.Button_Clear(_button);
     }
 }
 

--- a/scripts/yyIOManager.js
+++ b/scripts/yyIOManager.js
@@ -1015,6 +1015,7 @@ function    yyIOManager( )
 	this.ButtonDown = [];						// Whether the mouse button is down
 	this.ButtonReleased = [];					// Whether the mouse button was released
 	this.ButtonPressed = [];					// Whether the mouse button was pressed
+	this.ButtonCleared = [];					// Whether the mouse button has been "cleared" (suppressed) from GML
 	this.WheelDown = this.WheelUp = false;
 	    
 	this.KeyMap = [];						    // Translation map for keys
@@ -1031,7 +1032,7 @@ function    yyIOManager( )
         this.KeyMap[l] = l;
     }
     for(var l=0;l<MAX_BUTTONS;l++){
-        this.ButtonDown[l]= this.ButtonReleased[l]= this.ButtonPressed[l]=false;
+        this.ButtonDown[l]= this.ButtonReleased[l]= this.ButtonPressed[l] = this.ButtonCleared[l] = false;
     }
 
     this.Update = IO_Update;
@@ -1588,6 +1589,7 @@ function  Button_Clear(_button)
 	    this.ButtonDown[_button] = false;
 	    this.ButtonPressed[_button] = false;
 	    this.ButtonReleased[_button] = false;
+	    this.ButtonCleared[_button] = true;
     }
 }
 
@@ -1611,7 +1613,8 @@ function  Button_Clear_All()
 	    this.ButtonDown[i] = false;
 	    this.ButtonPressed[i] = false;
 	    this.ButtonReleased[i] = false;
-	}		
+	    this.ButtonCleared[i] = true;
+	}
 	this.WheelUp = false;
 	this.WheelDown = false;
 	
@@ -1733,87 +1736,26 @@ function    IO_Update()
     this.MouseY = g_EventMouseY;
     this.m_DoMouseButton = g_EventButtons;    
     
-    // LEFT mouse button.
-    if ((this.m_DoMouseButton & 1) != 0)
-    {
-        this.ButtonDown[0] = 1;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x1) != 0)
-        {
-        	this.ButtonPressed[0] = 1;        	
-		}
-	}
-	else {
-        this.ButtonDown[0] = 0;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x1) != 0)
-        {
-        	this.ButtonReleased[0] = 1;
-		}
-	}
-    	
-	// Right mouse button.
-    if ((this.m_DoMouseButton & 2) != 0)
-    {
-        this.ButtonDown[1] = 1;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x2) != 0)
-        {
-        	this.ButtonPressed[1] = 1;
-		}
-	}
-	else {
-        this.ButtonDown[1] = 0;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x2) != 0)
-        {
-        	this.ButtonReleased[1] = 1;
-		}
-	}
-	    
-	// Middle mouse button.
-    if ((this.m_DoMouseButton & 4) != 0)
-    {
-        this.ButtonDown[2] = 1;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x4) != 0)
-        {
-        	this.ButtonPressed[2] = 1;
-		}
-	}
-	else {
-        this.ButtonDown[2] = 0;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x4) != 0)
-        {
-        	this.ButtonReleased[2] = 1;
-		}
-	}
+	for(var i = 0; i < MAX_BUTTONS; ++i)
+	{
+		if ((this.m_DoMouseButton & (1 << i)) != 0)
+		{
+			if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & (1 << i)) != 0)
+			{
+				this.ButtonPressed[i] = true;
+				this.ButtonCleared[i] = false;
+			}
 
-	// side1 mouse button.
-    if ((this.m_DoMouseButton & 8) != 0)
-    {
-        this.ButtonDown[3] = 1;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x8) != 0)
-        {
-        	this.ButtonPressed[3] = 1;
+			this.ButtonDown[i] = !(this.ButtonCleared[i]);
 		}
-	}
-	else {
-        this.ButtonDown[3] = 0;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x8) != 0)
-        {
-        	this.ButtonReleased[3] = 1;
-		}
-	}
-	// side2 mouse button.
-    if ((this.m_DoMouseButton & 16) != 0)
-    {
-        this.ButtonDown[4] = 1;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x10) != 0)
-        {
-        	this.ButtonPressed[4] = 1;
-		}
-	}
-	else {
-        this.ButtonDown[4] = 0;        
-        if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & 0x10) != 0)
-        {
-        	this.ButtonReleased[4] = 1;
+		else {
+			this.ButtonDown[i] = false;
+
+			if (((this.m_DoMouseButton_Last ^ this.m_DoMouseButton) & (1 << i)) != 0)
+			{
+				this.ButtonReleased[i] = true;
+				this.ButtonCleared[i] = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
- Fixes spurious release events being triggered when mouse_clear() is called (https://github.com/YoYoGames/GameMaker-Bugs/issues/9295).

- Fixes button state being re-asserted when pointer is moved with the button still held down.