### PR TITLE
Text element split word wrapping, origin alignment

### DIFF
--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -380,14 +380,16 @@ function CLayerTextElement()
     this.m_blend=0xffffffff;  // blending for the text
     this.m_alpha=1;           // alpha transparency for the text
     this.m_originX=1;          // x scale factor
-    this.m_originY=1;          // y scale factor
+    this.m_originY = 1;          // y scale factor
+    this.m_origin = 0;
     this.m_text = "";           // text string to draw
     this.m_alignment=0;          // alignment   
     this.m_charSpacing=0;          // character spacing value
     this.m_lineSpacing=0;          // line spacing value
     this.m_frameW=-1;          // x scale factor
     this.m_frameH=-1;          // y scale factor
-    this.m_wrap=false;
+    this.m_wrap = false;
+    this.m_wrapMode = 0;
 
     this.m_type = eLayerElementType_Text;
     this.m_name = "";
@@ -2220,6 +2222,7 @@ LayerManager.prototype.BuildRoomLayers = function(_room,_roomLayers)
                         NewTextItem.m_alpha = ((pLayer.textitems[i].sBlend>>24)&0xff) / 255.0;                        
                         NewTextItem.m_originX = pLayer.textitems[i].sXOrigin;
                         NewTextItem.m_originY = pLayer.textitems[i].sYOrigin;
+                        NewTextItem.m_origin = pLayer.textitems[i].sOrigin;
                         NewTextItem.m_text = pLayer.textitems[i].sText;
                         NewTextItem.m_alignment = pLayer.textitems[i].sAlignment;
                         NewTextItem.m_charSpacing = pLayer.textitems[i].sCharSpacing;
@@ -2227,6 +2230,7 @@ LayerManager.prototype.BuildRoomLayers = function(_room,_roomLayers)
                         NewTextItem.m_frameW = pLayer.textitems[i].sFrameW;
                         NewTextItem.m_frameH = pLayer.textitems[i].sFrameH;
                         NewTextItem.m_wrap = (pLayer.textitems[i].sWrap != 0) ? true : false;
+                        NewTextItem.m_wrapMode = pLayer.textitems[i].sWrapMode;
                         NewTextItem.m_name = pLayer.textitems[i].sName;
                         
                         this.AddNewElement(_room,NewLayer,NewTextItem,false);
@@ -3547,6 +3551,14 @@ function layer_text_yorigin( _textelID,_yorigin)
     }
 };
 
+function layer_text_origin(_textelID, _origin)
+{
+    var el = layerTextGetElement(_textelID);
+    if (el != null) {
+        el.m_origin = yyGetInt32(_origin);
+    }
+};
+
 function layer_text_charspacing( _textelID,_charspacing) 
 {
     var el = layerTextGetElement(_textelID);
@@ -3589,6 +3601,14 @@ function layer_text_wrap( _textelID,_wrap)
     if (el != null)
     {
         el.m_wrap = yyGetBool(_wrap);
+    }
+};
+
+function layer_text_wrapmode(_textelID, _wrapMode)
+{
+    var el = layerTextGetElement(_textelID);
+    if (el != null) {
+        el.m_wrapMode = yyGetInt32(_wrapMode);
     }
 };
 
@@ -3722,6 +3742,15 @@ function layer_text_get_yorigin( _textelID)
     return 0;
 };
 
+function layer_text_get_origin(_textelID)
+{
+    var el = layerTextGetElement(_textelID);
+    if (el != null) {
+        return el.m_origin;
+    }
+    return 0;
+};
+
 function layer_text_get_charspacing( _textelID) 
 {
     var el = layerTextGetElement(_textelID);
@@ -3768,6 +3797,15 @@ function layer_text_get_wrap( _textelID)
     if (el != null)
     {
         return el.m_wrap;
+    }
+    return 0;
+};
+
+function layer_text_get_wrapmode(_textelID)
+{
+    var el = layerTextGetElement(_textelID);
+    if (el != null) {
+        return el.m_wrapMode;
     }
     return 0;
 };

--- a/scripts/functions/Function_Room.js
+++ b/scripts/functions/Function_Room.js
@@ -348,14 +348,16 @@ function room_get_info(_ind, _views, _instances, _layers, _layer_elements, _tile
                                     variable_struct_set( element, "x", sourceLayer.textitems[assetIdx].sX);
                                     variable_struct_set( element, "y", sourceLayer.textitems[assetIdx].sY);
                                     variable_struct_set( element, "xorigin", sourceLayer.textitems[assetIdx].sXOrigin);
-                                    variable_struct_set( element, "yorigin", sourceLayer.textitems[assetIdx].sYOrigin);
+                                    variable_struct_set(element, "yorigin", sourceLayer.textitems[assetIdx].sYOrigin);
+                                    variable_struct_set(element, "origin", sourceLayer.textitems[assetIdx].sOrigin);
                                     variable_struct_set( element, "h_align", sourceLayer.textitems[assetIdx].sAlignment & 0xff);
                                     variable_struct_set( element, "v_align", (sourceLayer.textitems[assetIdx].sAlignment >> 8) & 0xff);
                                     variable_struct_set( element, "char_spacing", sourceLayer.textitems[assetIdx].sCharSpacing);
                                     variable_struct_set( element, "line_spacing", sourceLayer.textitems[assetIdx].sLineSpacing);
                                     variable_struct_set( element, "frame_width", sourceLayer.textitems[assetIdx].sFrameW);
                                     variable_struct_set( element, "frame_height", sourceLayer.textitems[assetIdx].sFrameH);
-                                    variable_struct_set( element, "wrap", sourceLayer.textitems[assetIdx].sWrap);
+                                    variable_struct_set(element, "wrap", sourceLayer.textitems[assetIdx].sWrap);
+                                    variable_struct_set(element, "wrap_mode", sourceLayer.textitems[assetIdx].sWrapMode);
                                     variable_struct_set( element, "xscale", sourceLayer.textitems[assetIdx].sXScale);
                                     variable_struct_set( element, "yscale", sourceLayer.textitems[assetIdx].sYScale);
                                     variable_struct_set( element, "blend", sourceLayer.textitems[assetIdx].sBlend & 0x00ffffff );

--- a/scripts/yoga/GMYoga.js
+++ b/scripts/yoga/GMYoga.js
@@ -2595,13 +2595,15 @@ function UILayerTextElement(element_data, from_wad)
 		this.textColour           = element_data.textColour;
 		this.textOriginX          = element_data.textOriginX;
 		this.textOriginY          = element_data.textOriginY;
+		this.textOrigin			  = element_data.textOrigin;
 		this.textText             = element_data.textText;
 		this.textAlignment        = element_data.textAlignment;
 		this.textCharacterSpacing = element_data.textCharacterSpacing;
 		this.textLineSpacing      = element_data.textLineSpacing;
 		this.textFrameWidth       = element_data.textFrameWidth;
 		this.textFrameHeight      = element_data.textFrameHeight;
-		this.textWrap             = element_data.textWrap;
+		this.textWrap			  = element_data.textWrap;
+		this.textWrapMode		  =	element_data.textWrapMode;
 		this.textName             = element_data.textName;
 
 		this.flexVisible    = element_data.flexVisible;
@@ -2620,14 +2622,16 @@ function UILayerTextElement(element_data, from_wad)
 		this.textAngle            = yyGetReal(variable_struct_get(element_data, "textAngle"));
 		this.textColour           = yyGetInt32(variable_struct_get(element_data, "textColour"));
 		this.textOriginX          = yyGetReal(variable_struct_get(element_data, "textOriginX"));
-		this.textOriginY          = yyGetReal(variable_struct_get(element_data, "textOriginY"));
+		this.textOriginY		  = yyGetReal(variable_struct_get(element_data, "textOriginY"));
+		this.textOrigin			  = yyGetInt32(variable_struct_get(element_data, "textOrigin"));
 		this.textText             = yyGetString(variable_struct_get(element_data, "textText"));
 		this.textAlignment        = yyGetReal(variable_struct_get(element_data, "textAlignment"));
 		this.textCharacterSpacing = yyGetReal(variable_struct_get(element_data, "textCharacterSpacing"));
 		this.textLineSpacing      = yyGetReal(variable_struct_get(element_data, "textLineSpacing"));
 		this.textFrameWidth       = yyGetReal(variable_struct_get(element_data, "textFrameWidth"));
 		this.textFrameHeight      = yyGetReal(variable_struct_get(element_data, "textFrameHeight"));
-		this.textWrap             = yyGetBool(variable_struct_get(element_data, "textWrap"));
+		this.textWrap			  = yyGetBool(variable_struct_get(element_data, "textWrap"));
+		this.textWrapMode		  = yyGetInt32(variable_struct_get(element_data, "textWrapMode"));
 		this.textName             = undefined;
 
 		this.flexVisible    = yyGetBool(variable_struct_get(element_data, "flexVisible"));
@@ -2657,6 +2661,9 @@ UILayerTextElement.prototype.create_element = function(target_layer, run_instanc
 	NewTextItem.m_alpha = ((this.textColour >> 24) & 0xff) / 255.0;
 	NewTextItem.m_scaleX = this.textScaleX;
 	NewTextItem.m_scaleY = this.textScaleY;
+	NewTextItem.m_originX = this.textOriginX;
+	NewTextItem.m_originY = this.textOriginY;
+	NewTextItem.m_origin = this.textOrigin;
 	NewTextItem.m_text = this.textText;
 	NewTextItem.m_alignment = this.textAlignment;
 	NewTextItem.m_charSpacing = this.textCharacterSpacing;
@@ -2664,6 +2671,7 @@ UILayerTextElement.prototype.create_element = function(target_layer, run_instanc
 	NewTextItem.m_frameW = this.textFrameWidth;
 	NewTextItem.m_frameH = this.textFrameHeight;
 	NewTextItem.m_wrap = this.textWrap;
+	NewTextItem.m_wrapMode = this.textWrapMode;
 	NewTextItem.m_order = this.elementOrder;
 	NewTextItem.m_uiNode = this;
 
@@ -2898,14 +2906,16 @@ UILayerTextElement.prototype.serialise = function()
 	variable_struct_set(ret, "textAngle",            this.textAngle);
 	variable_struct_set(ret, "textColour",           this.textColour);
 	variable_struct_set(ret, "textOriginX",          this.textOriginX);
-	variable_struct_set(ret, "textOriginY",          this.textOriginY);
+	variable_struct_set(ret, "textOriginY",			 this.textOriginY);
+	variable_struct_set(ret, "textOrigin",			 this.textOrigin);
 	variable_struct_set(ret, "textText",             this.textText);
 	variable_struct_set(ret, "textAlignment",        this.textAlignment);
 	variable_struct_set(ret, "textCharacterSpacing", this.textCharacterSpacing);
 	variable_struct_set(ret, "textLineSpacing",      this.textLineSpacing);
 	variable_struct_set(ret, "textFrameWidth",       this.textFrameWidth);
 	variable_struct_set(ret, "textFrameHeight",      this.textFrameHeight);
-	variable_struct_set(ret, "textWrap",             this.textWrap);
+	variable_struct_set(ret, "textWrap",			 this.textWrap);
+	variable_struct_set(ret, "textWrapMode",		 this.textWrapMode);
 
 	variable_struct_set(ret, "flexVisible",   this.flexVisible);
 	variable_struct_set(ret, "flexAnchor",    this.flexAnchor);

--- a/scripts/yyFont.js
+++ b/scripts/yyFont.js
@@ -1956,6 +1956,34 @@ yyFontManager.prototype.Split_TextBlock = function (_pStr, linewidth, thefont) {
 	return sl;	
 };
 
+// #############################################################################################
+/// Function:<summary>
+///				Calculates maximum number of characters which will fit in given width for sub string
+///          </summary>
+///
+/// In:		 <param name="_pStr"></param>
+///			 <param name="_start">string start index</param>
+///			 <param name="_len">string character count to check</param>
+//			 <param name="_boundsWidth">width to fit</param>
+//			 <param name="_charSpacing">additional character spacing</param>
+/// Out:	 <returns>
+///				{ count : number of characters which fit (min 1) , measuredWidth : measured width of fitted string}
+///			 </returns>
+yyFontManager.prototype.MaxCharsToFitWidth = function (_pStr, _start, _len, _boundsWidth, _charSpacing) {
+	var ret = new Object();
+	for (var i = 1; i <= _len; ++i) {
+		var w = this.thefont.TextWidthN(_pStr, _start, i, _charSpacing);
+		if (w > _boundsWidth) {
+			ret.count = yymax(i - 1, 1);
+			ret.measuredWidth = this.thefont.TextWidthN(_pStr, _start, ret.count, _charSpacing);
+			return ret;
+		}
+	}
+	//all the chars fit boundsWidth
+	ret.count = _len;
+	ret.measuredWidth = this.thefont.TextWidthN(_pStr, _start, _len, _charSpacing);
+	return ret;
+};
 
 // #############################################################################################
 /// Function:<summary>
@@ -1969,7 +1997,7 @@ yyFontManager.prototype.Split_TextBlock = function (_pStr, linewidth, thefont) {
 ///				
 ///			 </returns>
 // #############################################################################################
-yyFontManager.prototype.Split_TextBlock_IDEstyle = function (_pStr, _boundsWidth, _boundsHeight, _alignment, _wrap, _charSpacing, _lineSpacing, _paraSpacing) {
+yyFontManager.prototype.Split_TextBlock_IDEstyle = function (_pStr, _boundsWidth, _boundsHeight, _alignment, _wrap, _wrapMode, _charSpacing, _lineSpacing, _paraSpacing) {
 
 	if (_pStr == null) return;	
 	
@@ -1993,6 +2021,7 @@ yyFontManager.prototype.Split_TextBlock_IDEstyle = function (_pStr, _boundsWidth
 	var textLines = [];
 	var start = 0;
 	var char = 0;
+	var bSplitWord = (_wrapMode == TTWRAPMODE_SplitWords);
 
 	while (char != len)
 	{
@@ -2072,54 +2101,115 @@ yyFontManager.prototype.Split_TextBlock_IDEstyle = function (_pStr, _boundsWidth
 					var extrawidthforspace = (lineWords > 0) ? spaceWidth : 0.0;
 					if ((lineWidth + wordWidth + extrawidthforspace) > _boundsWidth)
 					{
-						// Add what we've got
-						if (lineWords == 0)
+						if (wordWidth > _boundsWidth && bSplitWord)
 						{
-							// Even though we've overflowed, we only have a single word, so add it
-							lineWidth = wordWidth;
-							totalW = yymax(totalW, lineWidth);
+							//single word is too long to fit on single line - split over multiple lines
+							if (lineWords > 0)
+							{
+								//add the current lineWords
+								totalW = yymax(totalW, lineWidth);
+								lineData = new Object();
+								lineData.pString = str.substring(lineStart, wordEnd);
+								lineData.x = xpos;
+								lineData.y = ypos;
+								lineData.lineWidth = lineWidth;
+								lineData.wordSpacing = 0.0;
+								lineData.paragraphEnd = false;
+								lineData.numWords = lineWords;
+								sl[sl.length] = lineData;
+								
+								lineStart = wordStart;
+								ypos += lineHeight + _lineSpacing;
+							}
 
-							lineData = new Object();
-							lineData.pString = str.substring(lineStart, curr);
-							lineData.x = xpos;
-							lineData.y = ypos;
-							lineData.lineWidth = lineWidth;
-							lineData.wordSpacing = 0.0;
-							lineData.paragraphEnd = false;
-							lineData.numWords = 1;
+							//split long word over multiple lines
+							var remaining = curr - wordStart;
+							var chunkStart = wordStart;
+							while (remaining > 0)
+							{
+								var result = this.MaxCharsToFitWidth(str, chunkStart, remaining, _boundsWidth, _charSpacing);
+								var chunkLen = result.count;
+								var chunkWidth = result.measuredWidth;
 
-							sl[sl.length] = lineData;
+								remaining -= chunkLen;
+								if (remaining > 0) {
+									//add line with this chunk
+									var chunkEnd = chunkStart + chunkLen;
 
-							curr++;
+									lineData = new Object();
+									lineData.pString = str.substring(chunkStart, chunkEnd);
+									lineData.x = xpos;
+									lineData.y = ypos;
+									lineData.lineWidth = chunkWidth;
+									lineData.wordSpacing = 0.0;
+									lineData.paragraphEnd = false;
+									lineData.numWords = 1;
+									sl[sl.length] = lineData;
 
-							lineWidth = 0.0;
-							lineWords = 0;
-							lineStart = curr;
+									chunkStart = chunkEnd;
+									ypos += lineHeight + _lineSpacing;
+								}
+								else
+								{
+									//remaining chunk fits on line; no line output cos more words can be added; no need for terminator insert...right...
+									lineStart = chunkStart;
+									wordEnd = curr;
+									lineWidth = chunkWidth;
+									lineWords = 1;
+								}
+							}
 						}
 						else
 						{
-							// Add everything up to the previous word
-							totalW = yymax(totalW, lineWidth);
+							// Add what we've got
+							if (lineWords == 0)
+							{
+								// Even though we've overflowed, we only have a single word, so add it
+								lineWidth = wordWidth;
+								totalW = yymax(totalW, lineWidth);
 
-							lineData = new Object();
-							lineData.pString = str.substring(lineStart, wordEnd);
-							lineData.x = xpos;
-							lineData.y = ypos;
-							lineData.lineWidth = lineWidth;
-							lineData.wordSpacing = 0.0;
-							lineData.paragraphEnd = false;
-							lineData.numWords = lineWords;
+								lineData = new Object();
+								lineData.pString = str.substring(lineStart, curr);
+								lineData.x = xpos;
+								lineData.y = ypos;
+								lineData.lineWidth = lineWidth;
+								lineData.wordSpacing = 0.0;
+								lineData.paragraphEnd = false;
+								lineData.numWords = 1;
 
-							sl[sl.length] = lineData;
+								sl[sl.length] = lineData;
 
-							wordEnd = curr;
-							lineWidth = wordWidth;
-							lineWords = 1;
-							lineStart = wordStart;
+								curr++;
+
+								lineWidth = 0.0;
+								lineWords = 0;
+								lineStart = curr;
+							}
+							else
+							{
+								// Add everything up to the previous word
+								totalW = yymax(totalW, lineWidth);
+
+								lineData = new Object();
+								lineData.pString = str.substring(lineStart, wordEnd);
+								lineData.x = xpos;
+								lineData.y = ypos;
+								lineData.lineWidth = lineWidth;
+								lineData.wordSpacing = 0.0;
+								lineData.paragraphEnd = false;
+								lineData.numWords = lineWords;
+
+								sl[sl.length] = lineData;
+
+								wordEnd = curr;
+								lineWidth = wordWidth;
+								lineWords = 1;
+								lineStart = wordStart;
+							}
+
+							ypos += lineHeight;
+							ypos += _lineSpacing;
 						}
-
-						ypos += lineHeight;
-						ypos += _lineSpacing;
 					}
 					else
 					{
@@ -2622,6 +2712,18 @@ yyFontManager.prototype.GR_StringList_Draw_IDEstyle = function (_sl, _x, _y, _ch
 	}	
 };
 
+
+//Measure unwrapped text area with character / line / paragraph spacing applied
+yyFontManager.prototype.GR_Text_Measure_IDEStyle = function (_str, _fontID, _charSpacing, _lineSpacing, _paraSpacing) {
+	g_ActualTextWidth = g_ActualTextHeight = 0;
+	var oldFontID = draw_get_font();
+	draw_set_font(_fontID);
+	g_pFontManager.SetFont();
+	var sldata = g_pFontManager.Split_TextBlock_IDEstyle(_str, 0, 0, 0, false, 0, _charSpacing, _lineSpacing, _paraSpacing);
+	draw_set_font(oldFontID);
+	g_ActualTextWidth = sldata.totalW;
+	g_ActualTextHeight = sldata.totalH;
+};
 
 
 // #############################################################################################

--- a/scripts/yyRoom.js
+++ b/scripts/yyRoom.js
@@ -493,6 +493,7 @@ yyRoom.prototype.CloneStorage = function (_pStorage) {
 								sBlend: srcTextitem.sBlend,
 								sXOrigin: srcTextitem.sXOrigin,
 								sYOrigin: srcTextitem.sYOrigin,
+								sOrigin: srcTextitem.sOrigin,
 								sText: srcTextitem.sText,
 								sAlignment: srcTextitem.sAlignment,
 								sCharSpacing: srcTextitem.sCharSpacing,
@@ -500,6 +501,7 @@ yyRoom.prototype.CloneStorage = function (_pStorage) {
 								sFrameW: srcTextitem.sFrameW,
 								sFrameH: srcTextitem.sFrameH,
 								sWrap: srcTextitem.sWrap,
+								sWrapMode: srcTextitem.sWrapMode,
 								sName: srcTextitem.sName,								
 							};
 						}
@@ -1339,6 +1341,7 @@ yyRoom.prototype.DrawLayerTextElement = function(_rect,_layer,_el)
 		return;	// empty string so nothing to draw
 
 	var wrap = _el.m_wrap;
+	var wrapMode = _el.m_wrapMode;
 	var alignment = _el.m_alignment;
 	var fontID = _el.m_fontIndex;
 
@@ -1360,6 +1363,26 @@ yyRoom.prototype.DrawLayerTextElement = function(_rect,_layer,_el)
 	var angle = _el.m_angle;
 	var originX = _el.m_originX;
 	var originY = _el.m_originY;
+	var origin = _el.m_origin;
+	if (origin != 0)
+	{
+		var textW;
+		var textH;
+		if (wrap) {
+			textW = frameWidth;
+			textH = frameHeight;
+		}
+		else  //have to measure the text *before* draw to set origin correctly :( 
+		{ 
+			g_pFontManager.GR_Text_Measure_IDEStyle(pText, fontID, charSpacing, lineSpacing, paraSpacing);
+			textW = g_ActualTextWidth;
+			textH = g_ActualTextHeight;
+		}
+		var ox = (origin % 3) * textW * 0.5;
+		var oy = Math.floor(origin / 3) * textH * 0.5;
+		originX += ox;
+		originY += oy; 
+	}
 
 	var mats = [];	
 	var currmat = 0;	
@@ -1415,7 +1438,7 @@ yyRoom.prototype.DrawLayerTextElement = function(_rect,_layer,_el)
 		WebGL_SetMatrix(MATRIX_WORLD, newWorldMat);		
 	}
 
-	this.DrawTextItem(pText, fontID, drawcol, a, frameWidth, frameHeight, alignment, wrap, charSpacing, lineSpacing, paraSpacing, pFontParams, false);
+	this.DrawTextItem(pText, fontID, drawcol, a, frameWidth, frameHeight, alignment, wrap, wrapMode, charSpacing, lineSpacing, paraSpacing, pFontParams, false);
 
 	if (currmat > 0)
 	{
@@ -3052,7 +3075,7 @@ yyRoom.prototype.HandleSequenceParticle = function (_rect, _layer, _pSequenceEl,
 	}
 };
 
-yyRoom.prototype.DrawTextItem = function (_pText, _fontID, _drawcol, _drawalpha, _frameWidth, _frameHeight, _alignment, _wrap, _charSpacing, _lineSpacing, _paraSpacing, _pFontParams, _seqYOffset)
+yyRoom.prototype.DrawTextItem = function (_pText, _fontID, _drawcol, _drawalpha, _frameWidth, _frameHeight, _alignment, _wrap, _wrapMode, _charSpacing, _lineSpacing, _paraSpacing, _pFontParams, _seqYOffset)
 {
 	// @if feature("fonts")
 	var oldFontID = draw_get_font();
@@ -3064,7 +3087,7 @@ yyRoom.prototype.DrawTextItem = function (_pText, _fontID, _drawcol, _drawalpha,
 	draw_set_alpha(_drawalpha);
 
 	g_pFontManager.SetFont();
-	var sldata = g_pFontManager.Split_TextBlock_IDEstyle(_pText, _frameWidth, _frameHeight, _alignment, _wrap, _charSpacing, _lineSpacing, _paraSpacing);
+	var sldata = g_pFontManager.Split_TextBlock_IDEstyle(_pText, _frameWidth, _frameHeight, _alignment, _wrap, _wrapMode, _charSpacing, _lineSpacing, _paraSpacing);
 
 	var mask = _wrap && ((sldata.totalW > _frameWidth + 2) || (sldata.totalH > _frameHeight + 2));
 	if (mask)
@@ -3270,6 +3293,7 @@ yyRoom.prototype.HandleSequenceText = function (_rect, _layer, _pSequenceEl, _no
 		return;
 
 	var wrap = pTextKey.m_channels[0].wrap;
+	var wrapMode = pTextKey.m_channels[0].wrapMode;
 	var alignment = pTextKey.m_channels[0].alignment;
 	var fontID = pTextKey.m_channels[0].fontIndex;
 
@@ -3312,7 +3336,7 @@ yyRoom.prototype.HandleSequenceText = function (_rect, _layer, _pSequenceEl, _no
 
 	var pFontParams = _node.value.pFontEffectParams;
 
-	this.DrawTextItem(text, fontID, drawcol, a, frameWidth, frameHeight, alignment, wrap, charSpacing, lineSpacing, paraSpacing, pFontParams, true);	
+	this.DrawTextItem(text, fontID, drawcol, a, frameWidth, frameHeight, alignment, wrap, wrapMode, charSpacing, lineSpacing, paraSpacing, pFontParams, true);	
 };
 // @endif sequences
 

--- a/scripts/yySequence.js
+++ b/scripts/yySequence.js
@@ -188,6 +188,20 @@ TTALIGN_Top = 0;
 TTALIGN_VCentre = 1;
 TTALIGN_Bottom = 2;
 
+//text element origin
+TTORIGIN_TopLeft = 0;
+TTORIGIN_TopCentre = 1;
+TTORIGIN_TopRight = 2;
+TTORIGIN_MiddleLeft = 3;
+TTORIGIN_MiddleCentre = 4;
+TTORIGIN_MiddleRight = 5;
+TTORIGIN_BottomLeft = 6;
+TTORIGIN_BottomCentre = 7;
+TTORIGIN_BottomRight = 8;
+
+//text element wrap mode
+TTWRAPMODE_Default = 0;
+TTWRAPMODE_SplitWords = 1;
 
 SEQ_KEY_LENGTH_EPSILON = -0.0001;
 
@@ -3123,12 +3137,16 @@ function yyTextTrackKey(_pStorage)
 
     this.text = "";
     this.wrap = false;
+    this.wrapMode = 0;
+    this.origin = 0;
     this.alignment = 0;
     this.fontIndex = -1;
 
     if ((_pStorage != null) && (_pStorage != undefined)) {
         this.text = _pStorage.text;
         this.wrap = _pStorage.wrap;
+        this.wrapMode = _pStorage.wrapMode;
+        this.origin = _pStorage.origin;
         this.alignment = _pStorage.alignment;
         this.fontIndex = _pStorage.fontIndex;
     }
@@ -3143,6 +3161,16 @@ function yyTextTrackKey(_pStorage)
             enumerable: true,
             get: function () { return this.wrap; },
             set: function (_val) { this.wrap = yyGetBool(_val); }
+        },
+        gmlwrapMode: {
+            enumerable: true,
+            get: function () { return this.wrapMode; },
+            set: function (_val) { this.wrapMode = yyGetInt32(_val); }
+        },
+        gmlorigin: {
+            enumerable: true,
+            get: function () { return this.origin; },
+            set: function (_val) { this.origin = yyGetInt32(_val); }
         },
         gmlalignmentV: {
             enumerable: true,
@@ -4392,7 +4420,7 @@ yySequenceManager.prototype.IsLiveSequence = function (_seq)
 //returns: true if sequence with give id exists
 function _sequence_exists(_index)                   // need to add the underscore at the start so it doesn't class with the GML "sequence_exists"
 {
-    var pSequence = g_pSequenceManager.Get(_index);
+    var pSequence = g_pSequenceManager.GetSequenceFromID(_index);
     if( pSequence !== undefined && pSequence !== null )
         return true;
     return false;
@@ -4401,7 +4429,7 @@ function _sequence_exists(_index)                   // need to add the underscor
 //returns: name of sequence with given index, or empty string
 function sequence_get_name(_index)
 {
-    var pSequence = g_pSequenceManager.Get(_index);
+    var pSequence = g_pSequenceManager.GetSequenceFromID(_index);
     if( pSequence !== undefined && pSequence !== null )
         return pSequence.pName;
     return "";
@@ -5206,6 +5234,9 @@ yySequenceManager.prototype.HandleUpdateTracks = function (_el, _sequence, _inst
                     
                     this.HandleSequenceTrackUpdate(_el, _sequence, _instance, node.value, node.m_subtree, node, _matrix, _parentTrack, currentTrack, _headPosition, _lastHeadPosition, _headDirection, false, dirty);
                     break;
+                case eSTT_Text:
+                    this.HandleTextTrackUpdate(node.value, currentTrack, _headPosition, _sequence.m_length);
+                    break;
             }
 
             // Build matrix and eval tree for this track
@@ -5356,9 +5387,10 @@ yySequenceManager.prototype.HandleUpdateTracks = function (_el, _sequence, _inst
                     this.HandleParticleTrackUpdate(_el, _sequence, _instance, node.value, _matrix, currentTrack, _headPosition, _lastHeadPosition);
                     break;
 
-                case eSTT_Text:
-                    this.HandleTextTrackUpdate(node.value, currentTrack, _headPosition, _sequence.m_length);
-                    break;
+                //moved up before the MultiplyTrackMatrix above because we need to apply source origin
+                //case eSTT_Text:
+                //    this.HandleTextTrackUpdate(node.value, currentTrack, _headPosition, _sequence.m_length);
+                //    break;
             }
 
             if (currentTrack.m_tracks.length > 0)
@@ -6077,6 +6109,39 @@ yySequenceManager.prototype.HandleTextTrackUpdate = function(_srcVars, _track, _
 
     var textkey = keyframeStore.GetKeyframeAtFrame(_headPos, _seqLength);
     if (textkey == null) return;
+
+    //text track centre/edge origin adjustment
+    var origin = textkey.m_channels[0].origin;
+    if (origin != 0)
+    {
+        var wrap = textkey.m_channels[0].wrap;
+        var textWidth, textHeight;
+        if (wrap)
+        {
+            //origin is relative to frame size which we have already
+            textWidth = _srcVars.text.FrameSizeX;
+            textHeight = _srcVars.text.FrameSizeY;
+        }
+        else
+        {
+            //have to measure the text *before* draw to set the origin
+            var pText = textkey.m_channels[0].text;
+            var fontID = textkey.m_channels[0].fontIndex;
+            var charSpacing = _srcVars.CharacterSpacing;
+			var lineSpacing = _srcVars.LineSpacing;
+            var paraSpacing = _srcVars.ParagraphSpacing;
+            g_pFontManager.GR_Text_Measure_IDEStyle(pText, fontID, charSpacing, lineSpacing, paraSpacing);
+            textWidth = g_ActualTextWidth;
+            textHeight = g_ActualTextHeight;
+        }
+
+        var ox = (origin % 3) * textWidth * 0.5;
+        var oy = Math.floor(origin / 3) * textHeight * 0.5;
+        if (!_srcVars.Overrides(eT_OriginX))
+            _srcVars.xOrigin += ox;
+        if (!_srcVars.Overrides(eT_OriginY))
+            _srcVars.yOrigin += oy;
+    }
 
     // Check to see if we should enable particular effects 
 	// Need to check both whether the track exists and the actual track values 


### PR DESCRIPTION
RE [Allow Persistent Text Alignment for Room / Sequence Text elements](https://docs.google.com/document/d/1nUBAqtC1COC8NaSxuHIDDOWn5GlMo_r0D-jHCZT6QS4/edit?tab=t.0#heading=h.jis8c2cprwqh) https://github.com/YoYoGames/GameMaker-Bugs/issues/11637
-adds text element origin enum property for room and sequence text elements
And [Improve Text Element wrapping](https://docs.google.com/document/d/1c7ogZ1P0-dhWBkqMD81fEqUW3yMFi9OYg3Ur47RFHPg/edit?tab=t.0#heading=h.jis8c2cprwqh)
-adds wrapMode property for room and sequence text elements, split words checkbox in inspector