### PR TITLE
[HTML5] Various fixes from trying to run project attached to

### DIFF
--- a/scripts/functions/Function_Collision.js
+++ b/scripts/functions/Function_Collision.js
@@ -20,10 +20,7 @@ function Command_CollisionPoint(_pInst,_x,_y,_obj,_prec,_notme)
 	return Instance_SearchLoop(_pInst, yyGetInt32(_obj), yyGetBool(_notme), OBJECT_NOONE, _x, _y, _prec,
 		function( _pInstance )
 		{
-			if(_pInstance.GetCollisionDomain() != GetCollisionDomainForContext(_pInst))
-			{
-				return OBJECT_NOONE;
-			}
+			
 
 			var coll = _pInstance.Collision_Point(_x,_y,_prec);
 			if (!coll) {
@@ -39,10 +36,7 @@ function Command_CollisionPointList(_pInst,_x,_y,_obj,_prec,_notme,_list)
 {
 	Instance_SearchLoop(_pInst, yyGetInt32(_obj), yyGetBool(_notme), OBJECT_NOONE, _x, _y, _prec,
 		function( _pInstance ) {
-			if(_pInstance.GetCollisionDomain() != GetCollisionDomainForContext(_pInst))
-			{
-				return OBJECT_NOONE;
-			}
+			
 
 			if (_pInstance.Collision_Point(_x,_y,_prec)) {
 				_list.push(MAKE_REF(REFID_INSTANCE, _pInstance.id));

--- a/scripts/functions/Function_Layers.js
+++ b/scripts/functions/Function_Layers.js
@@ -4784,7 +4784,7 @@ function ShallowCopyVars( _dest, _other)
 {
     if (_other != undefined) {
         var props = Object.getOwnPropertyNames(_other);
-        props = props.filter(prop => prop.startsWith("gml") || g_obf2var[prop] != null);
+        props = props.filter(prop => prop.startsWith("gml") || (typeof g_obf2var!=="undefined" && g_obf2var[prop] != null));
         for (var i = 0; i < props.length; i++)
         {
             var prop = props[i];

--- a/scripts/yoga/GMYoga.js
+++ b/scripts/yoga/GMYoga.js
@@ -837,7 +837,14 @@ function flexpanel_node_get_struct( _node )
 // #######################################################################################
 function flexpanel_calculate_layout( _node, _width, _height, _direction)
 {	
-	_node.calculateLayout( yyGetReal(_width), yyGetReal(_height), _direction );
+
+	if(typeof(_width) != "undefined")
+		_width = yyGetReal(_width);
+
+	if(typeof(_height) != "undefined")
+		_height = yyGetReal(_height);
+
+	_node.calculateLayout( _width, _height, _direction );
 }
 
 // #######################################################################################
@@ -1817,7 +1824,7 @@ function UILayerInstanceElement(element_data, from_wad)
 		this.instanceScaleX      = yyGetReal(variable_struct_get(element_data, "instanceScaleX"));
 		this.instanceScaleY      = yyGetReal(variable_struct_get(element_data, "instanceScaleY"));
 		this.instanceImageSpeed  = yyGetReal(variable_struct_get(element_data, "instanceImageSpeed"));
-		this.instanceImageIndex  = yyGetReal(variable_struct_get(element_data, "instanceImageIndex"));
+		this.instanceImageIndex  = yyGetRef(variable_struct_get(element_data, "instanceImageIndex"));
 		this.instanceColour      = yyGetInt32(variable_struct_get(element_data, "instanceColour"));
 		this.instanceAngle       = yyGetReal(variable_struct_get(element_data, "instanceAngle"));
 


### PR DESCRIPTION
https://github.com/YoYoGames/GameMaker-Bugs/issues/11240

collision_point and collision_point_list on C++ runner don't check calling instance collision domain, so reflected this on html5 instanceImageIndex is a ref not a real
flexpanel_calculate_layout can be passed undefined legitimately, yyGetReal throws an error if it's called on this