### PR TITLE
Adjust weak_ref_alive to allow for "undefined" to match VM behavior

### DIFF
--- a/scripts/yyWeakRef.js
+++ b/scripts/yyWeakRef.js
@@ -87,7 +87,7 @@ function weak_ref_create(_pRef)
 
 function weak_ref_alive(_pWeakRef)
 {
-    if (_pWeakRef != undefined)
+    if (arguments.length > 0)
     {
         if ((typeof (_pWeakRef) == "object") && (_pWeakRef.__type != undefined) && (_pWeakRef.__type == "[weakref]"))
         {


### PR DESCRIPTION
At the moment, passing `undefined` into `weak_ref_alive` on HTML5 will cause `yyError("incorrect number of arguments to weak_ref_alive");` to be thrown. On VM/YYC, the function will return `undefined` without error.

This behavior *does not* match what occurs on VM (and YYC) and what is [stated in the documentation](https://manual.gamemaker.io/monthly/en/index.htm#t=GameMaker_Language%2FGML_Reference%2FGarbage_Collection%2Fweak_ref_alive.htm):
> Note that if you supply a value that is not a weak reference, the function will return undefined.

My PR adjusts `weak_ref_alive` to instead check if any arguments are provided, rather than checking for undefined. This brings the functionality to match VM and YYC as of beta v2024.1400.0.836