### PR TITLE
Fix for issue 681 - Forcing video element to playinline on iOS

### DIFF
--- a/scripts/yyVideo.js
+++ b/scripts/yyVideo.js
@@ -35,6 +35,8 @@ function video_open(path)
 
     if (gameCanvas.yyvideoplayer == null) {
         gameCanvas.yyvideoplayer = document.createElement('video');
+        gameCanvas.yyvideoplayer.setAttribute('webkit-playsinline', 'true');
+        gameCanvas.yyvideoplayer.setAttribute('playsinline', 'true');
     }
     else {
         gameCanvas.yyvideoplayer.pause();


### PR DESCRIPTION
Adding in webkit-playsinline and playsinline attribute to the created HTML5 Video element to make sure the video does not open the native video player on iOS. ([As mentioned in Issue 681](https://github.com/YoYoGames/GameMaker-HTML5/issues/681))