### PR TITLE
Audio queue existence

### DIFF
--- a/scripts/functions/Function_Sound.js
+++ b/scripts/functions/Function_Sound.js
@@ -3649,6 +3649,7 @@ function audio_free_play_queue(_queueId)
     queue_sounds[queueSoundId].bQueued = false;
     queue_sounds[queueSoundId] = undefined;
     delete queue_sounds[queueSoundId];
+    --g_queueSoundCount;
     return 0;
 }
 


### PR DESCRIPTION
[**GMB-11540**](https://github.com/YoYoGames/GameMaker-Bugs/issues/11540)
- Decrements the audio queue count after one is freed.