### PR TITLE
Fix for https://github.com/YoYoGames/GameMaker-Bugs/issues/11432

### DIFF
--- a/scripts/functions/Function_Sprite.js
+++ b/scripts/functions/Function_Sprite.js
@@ -1202,7 +1202,7 @@ function sprite_collision_mask( _ind, _sepmasks, _bbmode,_bbleft,_bbtop,_bbright
 
 		pSpr.SetBoundingBoxMode(_bbmode);
 		pSpr.SetBoundingBox(bbox);  /* will no-op if _bbmode != bboxmode_manual */
-		pSpr.ComputeBoundingBox();  /* will no-ip if _bbmode == bboxmode_manual */
+		pSpr.ComputeBoundingBox(_tolerance);  /* will no-op if _bbmode == bboxmode_manual */
 
 		if (_kind == 1)
 		{
@@ -1236,6 +1236,7 @@ function sprite_collision_mask( _ind, _sepmasks, _bbmode,_bbleft,_bbtop,_bbright
 
 		pSpr.SetBoundingBoxMode(_bbmode);
 		pSpr.SetBoundingBox(bbox); /* will no-op if _bbmode != bboxmode_manual */
+		pSpr.ComputeBoundingBox(_tolerance);  /* will no-op if _bbmode == bboxmode_manual */
 
 		// if bounding box mode, then don't assign sprites, just fill in the bounding box.
 

--- a/scripts/yySprite.js
+++ b/scripts/yySprite.js
@@ -319,8 +319,7 @@ yySprite.prototype.SetBoundingBoxMode = function(bboxmode)
 		return;
 	}
 
-	this.bboxmode = bboxmode;
-	this.ComputeBoundingBox();
+	this.bboxmode = bboxmode;	
 	this.MarkInstancesAsDirty();
 };
 
@@ -342,7 +341,7 @@ yySprite.prototype.SetBoundingBox = function(bbox)
 	}
 };
 
-yySprite.prototype.ComputeBoundingBox = function()
+yySprite.prototype.ComputeBoundingBox = function(_tolerance)
 {
 	if (this.bboxmode == 0 /* bboxmode_automatic */)
 	{


### PR DESCRIPTION
The yySprite ComputeBoundingBox() function was referencing a variable called "_tolerance" that was undefined (it looks like this was due to code being shuffled around). Also, there were some circumstances where ComputeBoundingBox() should have been called for non-Spine sprites and wasn't. Both of these issues have been fixed.