### PR TITLE
Using 'yyGetRef' before comparison in 'instance_(de)activate_object' …

### DIFF
--- a/scripts/functions/Function_Instance.js
+++ b/scripts/functions/Function_Instance.js
@@ -1681,8 +1681,9 @@ function instance_activate_object(_inst, _objindex)
 	    }
 	} else {	    
 	    for (var i = 0; i < pDeactiveList.pool.length; i++) {
-	        var pInst = pDeactiveList.pool[i];
-	        if (pInst.object_index == _objindex || pInst.id == _objindex) {
+			var pInst = pDeactiveList.pool[i];
+	        var instObjIndex = yyGetRef(pInst.object_index, REFID_OBJECT, undefined, undefined, true);
+	        if (instObjIndex == _objindex || pInst.id == _objindex) {
 	            keep[keep.length] = pInst;
 	        }
 	        else if (object_has_parent(g_pObjectManager.Get(pInst.object_index), _objindex)) {
@@ -1721,8 +1722,9 @@ function instance_deactivate_object(_inst, _objindex)
 	} 
 	else {	    
 	    for (var i = 0; i < pActiveList.pool.length; i++) {
-	        var pInst = pActiveList.pool[i];
-	        if (pInst.object_index == _objindex || pInst.id == _objindex) {
+			var pInst = pActiveList.pool[i];
+	        var instObjIndex = yyGetRef(pInst.object_index, REFID_OBJECT, undefined, undefined, true);
+			if (instObjIndex == _objindex || pInst.id == _objindex) {
 	            keep[keep.length] = pInst;
 	        }
 	        else if (object_has_parent(g_pObjectManager.Get(pInst.object_index), _objindex)) {


### PR DESCRIPTION
Hello!

My game is using instance_activate_object/instance_deactivate_object functions to handle accessibility of continue button on the pause screen, as well as some staged counting event on the score screen. These functions do not work properly in html5 build.
After some debugging, I came to this solution.

I guess, this is got to be an addition to ed5a9fa.

The issue reproduces on 2024.13.1.242 runtime (as well as on develop branch).

Have a nice day!