### PR TITLE
Add missing parameter to TextWidth usage in string_width.

### DIFF
--- a/scripts/functions/Function_Font.js
+++ b/scripts/functions/Function_Font.js
@@ -345,7 +345,7 @@ function string_height(_text) {
 // #############################################################################################
 function string_width(_text) {
 	g_pFontManager.SetFont();
-	return g_pFontManager.thefont ? g_pFontManager.thefont.TextWidth(yyGetString(_text)) : 1;
+	return g_pFontManager.thefont ? g_pFontManager.thefont.TextWidth(yyGetString(_text), undefined, 0) : 1;
 }
 
 

--- a/scripts/yyFont.js
+++ b/scripts/yyFont.js
@@ -851,7 +851,7 @@ yyFont.prototype.Draw_String_GL = function (_x, _y, _pStr, _xscale, _yscale, _an
 
     var bLerp=false;
     if ( (_col1 != _col2) || (_col3 != _col4) ) {
-        var strWidth = this.TextWidth(_pStr, true,0);
+        var strWidth = this.TextWidth(_pStr, true, 0);
         var invStrWidth = 1/strWidth;
         var alpha = _col1 & 0xff000000;
         bLerp = true;
@@ -2488,8 +2488,8 @@ yyFontManager.prototype.GR_Text_Draw = function (_str, x, y, linesep, linewidth,
 
 				if (pStr != null)
 				{				
-					if (this.halign == 1) xoff = -(xscale * thefont.TextWidth(pStr, true,0) / 2);
-					if (this.halign == 2) xoff = -(xscale * thefont.TextWidth(pStr, true,0));
+					if (this.halign == 1) xoff = -(xscale * thefont.TextWidth(pStr, true, 0) / 2);
+					if (this.halign == 2) xoff = -(xscale * thefont.TextWidth(pStr, true, 0));
 
 					var xx = passx + (cc * xoff) + (ss * yoff);
 					var yy = passy - (ss * xoff) + (cc * yoff);


### PR DESCRIPTION
Hello again!

One issue I mentioned in my game built with develop HTML5 runner is that string_width returns nan (missed pulsing tip text in the middle of the screen).

In addition to 65e9ed2, I specified parameters to TextWidth call (the missed one usage).

Have a nice day!