### PR TITLE
Addressing https://github.com/YoYoGames/GameMaker-Bugs/issues/12070

### DIFF
--- a/scripts/functions/Function_Graphics.js
+++ b/scripts/functions/Function_Graphics.js
@@ -2488,6 +2488,16 @@ function draw_get_enable_skeleton_blendmodes()
     return g_SpinePerSlotBlendmodes;
 }
 
+function draw_enable_skeleton_blend_override(_enable)
+{
+    g_SpineOverrideDefaultBlendmode = yyGetBool(_enable);
+}
+
+function draw_get_enable_skeleton_blend_override()
+{
+    return g_SpineOverrideDefaultBlendmode;
+}
+
 // #############################################################################################
 /// Function:<summary>
 ///             Dump out the list of animations belonging to a skeleton sprite


### PR DESCRIPTION
Adding a function to disable the blend mode override that's currently used if a Spine sprite atlas is using premultiplied alpha and the blend mode is currently set to the default.