### PR TITLE
Adds vertex_exists and vertex_format_exists

### DIFF
--- a/scripts/yyBufferVertex.js
+++ b/scripts/yyBufferVertex.js
@@ -46,6 +46,7 @@ var vertex_create_buffer,
     vertex_create_buffer_from_buffer_ext,
     vertex_update_buffer_from_buffer,
     vertex_update_buffer_from_vertex,
+    vertex_exists,
     draw_flush;
 
 // @if feature("2d")
@@ -78,6 +79,7 @@ var vertex_create_buffer,
     vertex_create_buffer_from_buffer_ext = _stub("vertex_create_buffer_from_buffer_ext", -1);
     vertex_update_buffer_from_buffer = _stub("vertex_update_buffer_from_buffer", -1);
     vertex_update_buffer_from_vertex = _stub("vertex_update_buffer_from_vertex", -1);
+    vertex_exists = _stub("vertex_exists", -1);
     draw_flush = ()=>{};
 })();
 // @endif
@@ -122,6 +124,7 @@ function InitBufferVertexFunctions() {
     vertex_submit_ext = WebGL_vertex_submit_ext_RELEASE;
     vertex_get_number = WebGL_vertex_get_number_RELEASE;
     vertex_get_buffer_size = WebGL_vertex_get_buffer_size_RELEASE;
+    vertex_exists = WebGL_vertex_exists;
     draw_flush = WebGL_draw_flush_RELEASE;
 }
 
@@ -756,6 +759,26 @@ function WebGL_vertex_get_number_RELEASE(_buffer)
     }
     
     return 0;
+}
+
+// #############################################################################################
+/// Function:<summary>
+///             Checks to see if a vertex buffer exists  or not.
+///          </summary>
+/// In:		<param name="_buffer">Buffer to check if it exists</param>
+/// Out:	<returns>
+///				Bool of vertex buffer existence.
+///			</returns>
+// #############################################################################################
+function WebGL_vertex_exists(_buffer)
+{
+    var vertexBuffer = g_vertexBuffers[yyGetInt32(_buffer)];
+    if (vertexBuffer)
+    {
+        return true;
+    }
+    
+    return false;
 }
 
 

--- a/scripts/yyVertexManager.js
+++ b/scripts/yyVertexManager.js
@@ -23,7 +23,8 @@ var vertex_format_begin,
     vertex_format_add_texcoord,
     vertex_format_add_textcoord,
     vertex_format_add_custom,
-    vertex_format_get_info;
+    vertex_format_get_info,
+    vertex_format_exists;
 
 // @if feature("2d")
 (() => {
@@ -40,6 +41,7 @@ var vertex_format_begin,
     vertex_format_add_textcoord = _stub("vertex_format_add_textcoord");
     vertex_format_add_custom = _stub("vertex_format_add_custom");
     vertex_format_get_info = _stub("vertex_format_get_info");
+    vertex_format_exists = _stub("vertex_format_exists");
 })();
 // @endif 2d
 
@@ -69,6 +71,7 @@ function InitFVFFunctions() {
     vertex_format_add_textcoord = WebGL_vertex_format_add_texcoord_RELEASE; //This was in wrongly, add both spellings...
     vertex_format_add_custom = WebGL_vertex_format_add_custom_RELEASE;
     vertex_format_get_info = WebGL_vertex_format_get_info_RELEASE;
+    vertex_format_exists = WebGL_vertex_format_exists;
 }
 
 // #############################################################################################
@@ -227,6 +230,20 @@ function WebGL_vertex_format_get_info_RELEASE(_format_id)
     variable_struct_set(pVFI, "elements", elementsArray);
 
     return pVFI;
+}
+
+// #############################################################################################
+/// Function:<summary>
+///          </summary>
+// #############################################################################################
+function WebGL_vertex_format_exists(_format_id)
+{
+    var format = g_webGL.GetVertexFormat(yyGetInt32(_format_id));
+
+    if (!format) 
+        return false;
+
+    return true;
 }
 // @endif gl
 


### PR DESCRIPTION
Addresses https://github.com/YoYoGames/GameMaker-Bugs/issues/3457.
The other related PR can be found here. https://github.com/GameMakerEnterprise/GMS2-Runner-Main/pull/33

This PR adds in both `vertex_exists(buffer)` and `vertex_format_exists(buffer)`, checking whether the vertex buffer, and vertex format exists, or not.

Use case:
```gml
// Create
vbuff = -1;
vformat = -1;

// Step/Elsewhere
if (!vertex_exists(vbuff)) {
  vbuff  = vertex_create_buffer();
}

if (!vertex_format_exists(vformat)) {
	vertex_format_begin();
	vertex_format_add_position_3d();
	vertex_format_add_texcoord();
	vertex_format_add_colour();
	vformat = vertex_format_end();	
}
```