### PR TITLE
Fix for https://github.com/YoYoGames/GameMaker-HTML5/issues/715

### DIFF
--- a/scripts/functions/Function_Graphics.js
+++ b/scripts/functions/Function_Graphics.js
@@ -2724,46 +2724,52 @@ function draw_get_svg_aa_level() {
 
 function vector_sprite_cache_limit(_limit)
 {
-    
+    ErrorFunction("vector_sprite_cache_limit");
 }
 
 function vector_sprite_cache_prune_fraction(_fraction)
 {
-    
+    ErrorFunction("vector_sprite_cache_prune_fraction");
 }
 
 function vector_sprite_cache_prune_age(_frames)
 {
-
+    ErrorFunction("vector_sprite_cache_prune_age");
 }
 
 function vector_sprite_cache_get_limit()
 {
+    ErrorFunction("vector_sprite_cache_get_limit");
     return 0;
 }
 
 function vector_sprite_cache_get_prune_fraction()
 {
+    ErrorFunction("vector_sprite_cache_get_prune_fraction");
     return 0;
 }
 
 function vector_sprite_cache_get_prune_age()
 {
+    ErrorFunction("vector_sprite_cache_get_prune_age");
     return 0;
 }
 
 function vector_sprite_cache_get_used()
 {
+    ErrorFunction("vector_sprite_cache_get_used");
     return 0;
 }
 
 function vector_sprite_cache_get_max_used()
 {
+    ErrorFunction("vector_sprite_cache_get_max_used");
     return 0;
 }
 
 function vector_sprite_cache_get_oldest_entry_age()
 {
+    ErrorFunction("vector_sprite_cache_get_oldest_entry_age");
     return 0;
 }
 

--- a/scripts/functions/Function_Graphics.js
+++ b/scripts/functions/Function_Graphics.js
@@ -2722,6 +2722,52 @@ function draw_get_svg_aa_level() {
     return GR_SVGAAScale;
 };
 
+function vector_sprite_cache_limit(_limit)
+{
+    
+}
+
+function vector_sprite_cache_prune_fraction(_fraction)
+{
+    
+}
+
+function vector_sprite_cache_prune_age(_frames)
+{
+
+}
+
+function vector_sprite_cache_get_limit()
+{
+    return 0;
+}
+
+function vector_sprite_cache_get_prune_fraction()
+{
+    return 0;
+}
+
+function vector_sprite_cache_get_prune_age()
+{
+    return 0;
+}
+
+function vector_sprite_cache_get_used()
+{
+    return 0;
+}
+
+function vector_sprite_cache_get_max_used()
+{
+    return 0;
+}
+
+function vector_sprite_cache_get_oldest_entry_age()
+{
+    return 0;
+}
+
+
 
 function SetViewExtents(xview, yview, wview, hview,  angle)
 {

--- a/scripts/functions/Function_Misc.js
+++ b/scripts/functions/Function_Misc.js
@@ -140,3 +140,13 @@ function gc_get_stats()
 
     return resobj;
 }
+
+function gc_target_frame_time(_time)
+{
+
+}
+
+function gc_get_target_frame_time()
+{
+    return 0;
+}

--- a/scripts/functions/Function_Misc.js
+++ b/scripts/functions/Function_Misc.js
@@ -109,16 +109,17 @@ function extension_get_options(_extension_name)
 
 function gc_collect()
 {
-
+    ErrorFunction("gc_collect");
 }
 
 function gc_enable(_enable)
 {
-
+    ErrorFunction("gc_enable");
 }
 
 function gc_is_enabled()
 {
+    ErrorFunction("gc_is_enabled");
     return true;
 }
 
@@ -143,10 +144,11 @@ function gc_get_stats()
 
 function gc_target_frame_time(_time)
 {
-
+    ErrorFunction("gc_target_frame_time");
 }
 
 function gc_get_target_frame_time()
 {
+    ErrorFunction("gc_get_target_frame_time");
     return 0;
 }


### PR DESCRIPTION
- Added stubbed version of missing gc_target_frame_time() function
- Also added several other missing functions I found.