### PR TITLE
GMB-12150: Fix ref type of particles in room_get_info

### DIFF
--- a/scripts/functions/Function_Room.js
+++ b/scripts/functions/Function_Room.js
@@ -325,7 +325,7 @@ function room_get_info(_ind, _views, _instances, _layers, _layer_elements, _tile
                                     element.__yyIsGMLObject = true;
                                     variable_struct_set( element, "type", 6 );
                                     variable_struct_set( element, "id", srcParticle.sName );
-                                    variable_struct_set( element, "ps", MAKE_REF(REFID_PART_SYSTEM, srcParticle.sIndex) );
+                                    variable_struct_set( element, "ps", MAKE_REF(REFID_PARTICLESYSTEM, srcParticle.sIndex) );
                                     variable_struct_set( element, "x", srcParticle.sX);
                                     variable_struct_set( element, "y", srcParticle.sY);
                                     variable_struct_set( element, "xscale", srcParticle.sXScale);


### PR DESCRIPTION
Issue link: https://github.com/YoYoGames/GameMaker-Bugs/issues/12268
