### PR TITLE
[HTML5] Fix for room_instance_add

### DIFF
--- a/scripts/functions/Function_Room.js
+++ b/scripts/functions/Function_Room.js
@@ -738,6 +738,11 @@ function room_instance_add(_ind,_x,_y,_obj)
             index: yyGetInt32(_obj), 
             id: instance_id };
 
+        if(!g_DoneFirstRoomCreation)
+        {
+            var storageIndex = pRoom.m_pStorage.creationOrderIds.length;
+            pRoom.m_pStorage.creationOrderIds[storageIndex] = instance_id;
+        }  
         pRoom.m_creationOrder.push(pRoom.m_pStorage.pInstances[instanceIndex]);
 
 		return MAKE_REF(REFID_INSTANCE, instance_id);


### PR DESCRIPTION
As per C++ runner, append to creationorderids when adding to storage

https://github.com/YoYoGames/GameMaker-Bugs/issues/12260