### PR TITLE
Fix variable_clone for arrays

### DIFF
--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -2857,6 +2857,7 @@ function __internal_variable_clone(_val, _depth) {
         if (_val instanceof Array) {
 
             var clone = new Array(_val.length);
+			__yy_gml_array_create(clone);
             g_CLONE_VISITED_LIST.set(_val, clone);
 
             for (var n = 0; n < _val.length; ++n) {
@@ -2913,4 +2914,5 @@ function variable_clone(_val, _depth) {
 
     return clone;
 } // end variable_clone
+
 


### PR DESCRIPTION
When using variable_clone on an array, the `__yy_owner` property was not being set, breaking array value assignment when the array is passed around by reference due to `__yy_owner` not matching `g_CurrentArrayOwner` inside `__yy_gml_array_check`

<img width="330" height="106" alt="image" src="https://github.com/user-attachments/assets/c50c07f2-a534-4506-85ef-6745f6f9f6a0" />
