### PR TITLE
Fix variable_clone for pointer constants

### DIFF
--- a/scripts/yyVariable.js
+++ b/scripts/yyVariable.js
@@ -2842,6 +2842,11 @@ function __internal_variable_clone(_val, _depth) {
     }
 
     if (typeof _val === "object") {
+
+		// Handle pointer constants
+		if (_val === g_pBuiltIn.pointer_null || _val === g_pBuiltIn.pointer_invalid) {
+            return _val;
+        }
         
         // Are we an int64?
         if (_val instanceof Long) {
@@ -2914,5 +2919,6 @@ function variable_clone(_val, _depth) {
 
     return clone;
 } // end variable_clone
+
 
 


### PR DESCRIPTION
Currently pointer_null when cloned will manifest as an empty object in the clone struct:
<img width="287" height="76" alt="image" src="https://github.com/user-attachments/assets/5b6c8778-72be-48e9-8482-63ad3a6663d7" />
