### PR TITLE
Implement `flexpanel_set_rounding_scale` function

### DIFF
--- a/scripts/yoga/GMYoga.js
+++ b/scripts/yoga/GMYoga.js
@@ -1,6 +1,7 @@
 // @if feature("flexpanel")
 const Yoga = require('/yoga-wasm-base64-csm.js');
 var g_yoga = null;
+var g_yogaConfig = null;
 var g_UILayers = null;
 
 /// Global flag: **true** after the first UI-layer layout pass has completed.
@@ -9,6 +10,7 @@ var g_UILayersInit = false;
 async function flexpanel_init()
 {
 	g_yoga = await Yoga();
+    g_yogaConfig = g_yoga["Config"]["create"]();
 }
 flexpanel_init();
 
@@ -218,7 +220,7 @@ function FLEXPANEL_Init_From_Struct(_node, _struct, _from_wad)
 			flexpanel_node_remove_all_children(_node);
 			for( var n=0; n<value.length; ++n) {
 
-				var child = g_yoga["Node"]["createDefault"]();
+				var child = g_yoga["Node"]["createWithConfig"](g_yogaConfig);
 				FLEXPANEL_CreateContext( child );
 				_node.insertChild( child, n );
 
@@ -484,7 +486,7 @@ function FLEXPANEL_Handle_Struct( _node, _struct, _from_wad)
 // #######################################################################################
 function flexpanel_create_node( _struct )
 {	
-	var ret = g_yoga[ "Node" ]["createDefault"]();
+	var ret = g_yoga["Node"]["createWithConfig"](g_yogaConfig);
 	FLEXPANEL_CreateContext(ret);
 	FLEXPANEL_Handle_Struct( ret, _struct, false );
 	return ret;
@@ -880,6 +882,16 @@ function flexpanel_node_layout_get_position( _node, _relative )
     variable_struct_set(ret, "right", right + x);
 
 	return ret;
+}
+
+function flexpanel_set_rounding_scale( _scaleFactor )
+{
+	var roundingScale = yyGetReal(_scaleFactor);
+	if (roundingScale < 0) {
+		yyError("rounding scale factor should not be less than zero");
+	}
+
+    g_yogaConfig.setPointScaleFactor(roundingScale);
 }
 
 // #######################################################################################
@@ -1415,7 +1427,7 @@ function UILayers_Create()
 			layer_type = eLAYER_GUI_IN_VIEW;
 		}
 
-		var node = g_yoga[ "Node" ]["createDefault"]();
+		var node = g_yoga["Node"]["createWithConfig"](g_yogaConfig);
 		FLEXPANEL_CreateContext(node);
 		FLEXPANEL_Handle_Struct(node, layer_data, true);
 


### PR DESCRIPTION
Issue: https://github.com/YoYoGames/GameMaker-Bugs/issues/12847
Main runtime pull request: https://github.com/GameMakerEnterprise/GMS2-Runner-Main/pull/39
HTML5 Demo: [itch.io](https://musnik.itch.io/flexbox-rounding-test) (password: `gamemaker`)

This implements Yoga's [rounding scale factor](https://www.yogalayout.dev/docs/getting-started/configuring-yoga#point-scale-factor) by adding a new function:
```js
flexpanel_set_rounding_scale(scaleFactor);
```

The `scaleFactor` argument is the ratio between flexpanels' points and points on the render target. So the value of 1 will round layout values to the nearest render target's pixel, value of 0.5 will snap values to the grid of 2 pixels and the value of 2 will snap to 0.5 pixel grid doubling the precision. Inside it basically multiplies values by a scale factor before the rounding. 0 disables the rounding,

This can be useful to mitigate the issues I have on my bug report, for rendering on GUI layer that is not scaled 1:1 to the back buffer, rendering on scaled surfaces and for pixelart games' UI.

There's also a sample project that I used to test the results (same as HTML5 demo): https://api.gamemaker.io/api/github/downloads/f0a4d36d-fe9c-416f-a6f8-ff3eb5994de2
Uncomment the lines with `flexpanel_set_rounding_scale` calls after checking out the commit and adding the function to GMAC.