### PR TITLE
Fixing numPoints being altered by Proxy

### DIFF
--- a/scripts/yyAnimCurve.js
+++ b/scripts/yyAnimCurve.js
@@ -597,8 +597,9 @@ function yyAnimCurve(_pStorage) {
     if ((_pStorage != null) && (_pStorage != undefined)) {
         this.pName = _pStorage.pName;
         this.m_graphType = _pStorage.graphType;
-        this.m_numChannels = _pStorage.channels.length;        
-        for (var channelIndex = 0; channelIndex < this.m_numChannels; ++channelIndex) {
+        this.m_numChannels = _pStorage.channels.length;
+        let numChannels = this.m_numChannels;       
+        for (var channelIndex = 0; channelIndex < numChannels; ++channelIndex) {
             this.m_channels[channelIndex] = new yyAnimCurveChannel(_pStorage.channels[channelIndex]);
         }
         this.fromWAD = true;

--- a/scripts/yyAnimCurve.js
+++ b/scripts/yyAnimCurve.js
@@ -123,7 +123,8 @@ function yyAnimCurveChannel(_pStorage) {
         this.m_curveType = _pStorage.function;
         this.m_iterations = _pStorage.iterations;
         this.m_numPoints = _pStorage.points.length;        
-        for (var pointIndex = 0; pointIndex < this.m_numPoints; ++pointIndex) {
+        let numPoints = this.m_numPoints;
+        for (var pointIndex = 0; pointIndex < numPoints; ++pointIndex) {
             this.m_points[pointIndex] = new yyAnimCurvePoint(_pStorage.points[pointIndex]);
         }
     }


### PR DESCRIPTION
## Why?
To resolve the issue with number of points of animation curve setting to 1 once new point was created.

UPD: same applies to channels within curve.

## Severity: high
Using `animcurve_get_channel()` crashes game since it requires to have more than 2 points to evaluate the curve.

## Explanation
After introduction of the `this.m_points = new EnhancedArray();` `m_points` turned into `Proxy`.

The following loop `for (var pointIndex = 0; pointIndex < this.m_numPoints; ++pointIndex) {` relied on `this.m_numPoints`.

On point creation within the loop `this.m_points.SetIndex` was executed which updates points count with `this.self.m_numPoints = this.length;` which in order will always be 1 (only one point created so far).

That will prevent for loop to continue only leaving curve with one point.

