### PR TITLE
[Fonts] Fix for textheight being based on scalex rather than scaley

### DIFF
--- a/scripts/Unsupported.js
+++ b/scripts/Unsupported.js
@@ -157,7 +157,7 @@ function draw_set_alpha_test_ref_value()        { ErrorFunction("draw_set_alpha_
 function draw_get_alpha_test()                  { ErrorFunction("draw_get_alpha_test()"); return 0; }
 function draw_get_alpha_test_ref_value()        { ErrorFunction("draw_get_alpha_test_ref_value()"); return 0; }
 
-
+function gx_share()								{ErrorFunction("gx_share");}
 
 function zip_unzip()                                { ErrorFunction("zip_unzip()"); }
 function zip_create()                               { ErrorFunction("zip_create()"); }

--- a/scripts/yyFont.js
+++ b/scripts/yyFont.js
@@ -415,10 +415,10 @@ yyFont.prototype.TextHeight = function (_str) {
     if ((!_str) || (0 === _str.length)) return 0;
     
 	if (this.runtime_created) {
-		return this.size * this.scalex;
+		return this.size * this.scaley;
 	} 
 	else {	    
-	    return this.max_glyph_height * this.scalex;
+	    return this.max_glyph_height * this.scaley;
 	}
 };
 


### PR DESCRIPTION
(Not entirely sure there is a circumstance where these can be different, but if there is we should be reading .y)

Plus sneaked in a stub for gx_share

https://github.com/YoYoGames/GameMaker-HTML5/issues/387