### PR TITLE
Sequence Editor: Text elements in a sequence have their origin shifte…

### DIFF
--- a/scripts/yyRoom.js
+++ b/scripts/yyRoom.js
@@ -3340,7 +3340,7 @@ yyRoom.prototype.HandleSequenceText = function (_rect, _layer, _pSequenceEl, _no
 
 	var pFontParams = _node.value.pFontEffectParams;
 
-	this.DrawTextItem(text, fontID, drawcol, a, frameWidth, frameHeight, alignment, wrap, wrapMode, charSpacing, lineSpacing, paraSpacing, pFontParams, true);	
+	this.DrawTextItem(text, fontID, drawcol, a, frameWidth, frameHeight, alignment, wrap, wrapMode, charSpacing, lineSpacing, paraSpacing, pFontParams, false);	
 };
 // @endif sequences
 


### PR DESCRIPTION
…d, making them scale incorrectly and causing a gap at the top of the frame #14043
https://github.com/YoYoGames/GameMaker-Bugs/issues/14043