### PR TITLE
[Flexpanels] Return context clipContent flag in flexpanel_node_get_st…

### DIFF
--- a/scripts/yoga/GMYoga.js
+++ b/scripts/yoga/GMYoga.js
@@ -488,7 +488,8 @@ function flexpanel_create_node( _struct )
 {	
 	var ret = g_yoga["Node"]["createWithConfig"](g_yogaConfig);
 	FLEXPANEL_CreateContext(ret);
-	FLEXPANEL_Handle_Struct( ret, _struct, false );
+	if(_struct!==undefined)
+		FLEXPANEL_Handle_Struct( ret, _struct, false );
 	return ret;
 }
 
@@ -820,6 +821,11 @@ function flexpanel_node_get_struct( _node )
 		} // end for
     	variable_struct_set(ret, "nodes", nodes);		
 	} // end if
+
+	if(context.clip_content!==undefined)
+	{
+		variable_struct_set(ret, "clipContent", context.clip_content);
+	}
 
 	if(context.elements !== undefined && context.elements.length > 0)
 	{


### PR DESCRIPTION
…ruct

plus fixed a crash if you called

var _new_child = flexpanel_create_node();

(with no struct)

https://github.com/YoYoGames/GameMaker-Bugs/issues/14186