### PR TITLE
Use Date.getTime() for RNG seed

### DIFF
--- a/scripts/functions/Function_Maths.js
+++ b/scripts/functions/Function_Maths.js
@@ -613,7 +613,7 @@ function random_set_seed( _val )
 function randomize() 
 {
 	var d =  new Date();
-	var t = d.getMilliseconds() * 1000;
+	var t = d.getTime();
 	t = (t & 0xffffffff) ^ ((t >> 16) & 0xffff) ^ ((t << 16) & 0xffff0000);
     return InitRandomExt( t );
 }


### PR DESCRIPTION
randomize() now uses d.getTime() instead of d.getMilliseconds() * 1000 to derive the seed. This provides the full millisecond timestamp (higher resolution and wider range) for InitRandomExt(t), improving entropy for the RNG seed while keeping the existing bit-mixing logic.

Fixes: #605 